### PR TITLE
Run example chain tests on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: go
 install: true
 
 script:
-  - make test
+  - make testall
 
 cache:
     directories:

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,16 @@ hc: deps
 bs: deps
 	go install ./cmd/bs
 	gx-go rewrite --undo
-test: deps
+init: hc
+	hc init node@example.com
+test: testcore
+	gx-go rewrite --undo
+testcore: deps
 	go get -t
 	go test -v ./...||exit 1
-	gx-go rewrite --undo
+testall: testcore hc init
+	hc --debug --verbose clone --force examples/chat   examples-chat   && hc --debug --verbose test examples-chat
+	hc --debug --verbose clone --force examples/sample examples-sample && hc --debug --verbose test examples-sample
 deps: gx
 	gx-go rewrite
 	go get -d ./...


### PR DESCRIPTION
In order to expose issues like https://github.com/metacurrency/holochain/issues/101 I suggest we run the tests for chains in examples/* (at least those with good tests) on CI, after running the actual holochain tests.  

This PR does exactly that.

Here it is running against the dev branch, exposing the error from https://github.com/metacurrency/holochain/issues/101 -- https://travis-ci.org/metacurrency/holochain/builds/212032576

Bonus: when I apply (basically) the same commit to the master branch ( https://github.com/harlantwood/holochain/commit/1443bfadcdb72e7280582651380c30114d3b3b80 ), the build fails correctly because chain tests fail: https://travis-ci.org/harlantwood/holochain/builds/212029320
