### PR TITLE
Json test inputs

### DIFF
--- a/examples/sample/test/grouped.json
+++ b/examples/sample/test/grouped.json
@@ -1,1 +1,18 @@
-[{"Zome":"jsZome","FnName":"addOdd","Input":"7","Output":"%h%","Err":"","Regexp":""},{"Zome":"jsZome","FnName":"addOdd","Input":"2","Output":"","Err":"Invalid entry: 2","Regexp":""}]
+[
+  {
+    "Zome": "jsZome",
+    "FnName": "addOdd",
+    "Input": "7",
+    "Output": "%h%",
+    "Err": "",
+    "Regexp": ""
+  },
+  {
+    "Zome": "jsZome",
+    "FnName": "addOdd",
+    "Input": "2",
+    "Output": "",
+    "Err": "Invalid entry: 2",
+    "Regexp": ""
+  }
+]

--- a/examples/sample/test/test_0.json
+++ b/examples/sample/test/test_0.json
@@ -1,1 +1,10 @@
-[{"Zome":"myZome","FnName":"addData","Input":"2","Output":"%h%","Err":"","Regexp":""}]
+[
+  {
+    "Zome": "myZome",
+    "FnName": "addData",
+    "Input": "2",
+    "Output": "%h%",
+    "Err": "",
+    "Regexp": ""
+  }
+]

--- a/examples/sample/test/test_1.json
+++ b/examples/sample/test/test_1.json
@@ -1,1 +1,10 @@
-[{"Zome":"myZome","FnName":"addData","Input":"4","Output":"%h%","Err":"","Regexp":""}]
+[
+  {
+    "Zome": "myZome",
+    "FnName": "addData",
+    "Input": "4",
+    "Output": "%h%",
+    "Err": "",
+    "Regexp": ""
+  }
+]

--- a/examples/sample/test/test_2.json
+++ b/examples/sample/test/test_2.json
@@ -1,1 +1,10 @@
-[{"Zome":"myZome","FnName":"addData","Input":"5","Output":"","Err":"Error calling 'commit': Invalid entry: 5","Regexp":""}]
+[
+  {
+    "Zome": "myZome",
+    "FnName": "addData",
+    "Input": "5",
+    "Output": "",
+    "Err": "Error calling 'commit': Invalid entry: 5",
+    "Regexp": ""
+  }
+]

--- a/examples/sample/test/test_3.json
+++ b/examples/sample/test/test_3.json
@@ -1,1 +1,10 @@
-[{"Zome":"myZome","FnName":"addPrime","Input":"{\"prime\":7}","Output":"\"%h%\"","Err":"","Regexp":""}]
+[
+  {
+    "Zome": "myZome",
+    "FnName": "addPrime",
+    "Input": "{\"prime\":7}",
+    "Output": "\"%h%\"",
+    "Err": "",
+    "Regexp": ""
+  }
+]

--- a/examples/sample/test/test_3.json
+++ b/examples/sample/test/test_3.json
@@ -2,7 +2,7 @@
   {
     "Zome": "myZome",
     "FnName": "addPrime",
-    "Input": "{\"prime\":7}",
+    "Input": {"prime":7},
     "Output": "\"%h%\"",
     "Err": "",
     "Regexp": ""

--- a/examples/sample/test/test_4.json
+++ b/examples/sample/test/test_4.json
@@ -1,1 +1,10 @@
-[{"Zome":"myZome","FnName":"addPrime","Input":"{\"prime\":4}","Output":"","Err":"Error calling 'commit': Invalid entry: {\"Atype\":\"hash\", \"prime\":4, \"zKeyOrder\":[\"prime\"]}","Regexp":""}]
+[
+  {
+    "Zome": "myZome",
+    "FnName": "addPrime",
+    "Input": "{\"prime\":4}",
+    "Output": "",
+    "Err": "Error calling 'commit': Invalid entry: {\"Atype\":\"hash\", \"prime\":4, \"zKeyOrder\":[\"prime\"]}",
+    "Regexp": ""
+  }
+]

--- a/examples/sample/test/test_4.json
+++ b/examples/sample/test/test_4.json
@@ -2,7 +2,7 @@
   {
     "Zome": "myZome",
     "FnName": "addPrime",
-    "Input": "{\"prime\":4}",
+    "Input": {"prime":4},
     "Output": "",
     "Err": "Error calling 'commit': Invalid entry: {\"Atype\":\"hash\", \"prime\":4, \"zKeyOrder\":[\"prime\"]}",
     "Regexp": ""

--- a/examples/sample/test/test_5.json
+++ b/examples/sample/test/test_5.json
@@ -2,7 +2,10 @@
   {
     "Zome": "jsZome",
     "FnName": "addProfile",
-    "Input": "{\"firstName\":\"Art\",\"lastName\":\"Brock\"}",
+    "Input": {
+      "firstName": "Art",
+      "lastName": "Brock"
+    },
     "Output": "\"%h%\"",
     "Err": "",
     "Regexp": ""

--- a/examples/sample/test/test_5.json
+++ b/examples/sample/test/test_5.json
@@ -1,1 +1,10 @@
-[{"Zome":"jsZome","FnName":"addProfile","Input":"{\"firstName\":\"Art\",\"lastName\":\"Brock\"}","Output":"\"%h%\"","Err":"","Regexp":""}]
+[
+  {
+    "Zome": "jsZome",
+    "FnName": "addProfile",
+    "Input": "{\"firstName\":\"Art\",\"lastName\":\"Brock\"}",
+    "Output": "\"%h%\"",
+    "Err": "",
+    "Regexp": ""
+  }
+]

--- a/examples/sample/test/test_6.json
+++ b/examples/sample/test/test_6.json
@@ -1,1 +1,10 @@
-[{"Zome":"myZome","FnName":"getDNA","Input":"","Output":"%dna%","Err":"","Regexp":""}]
+[
+  {
+    "Zome": "myZome",
+    "FnName": "getDNA",
+    "Input": "",
+    "Output": "%dna%",
+    "Err": "",
+    "Regexp": ""
+  }
+]

--- a/holochain.go
+++ b/holochain.go
@@ -639,7 +639,7 @@ func (s *Service) Clone(srcPath string, root string, new bool) (hP *Holochain, e
 type TestData struct {
 	Zome   string
 	FnName string
-	Input  string
+	Input  interface{}
 	Output string
 	Err    string
 	Regexp string
@@ -1194,7 +1194,9 @@ func LoadTestData(path string) (map[string][]TestData, error) {
 					return nil, err
 				}
 				var t []TestData
+
 				err = json.Unmarshal(v, &t)
+
 				if err != nil {
 					return nil, err
 				}
@@ -1275,7 +1277,23 @@ func (h *Holochain) Test() []error {
 			time.Sleep(time.Millisecond * 10)
 			if err == nil {
 				testID := fmt.Sprintf("%s:%d", name, i)
-				input := t.Input
+
+				var input string
+				switch inputType := t.Input.(type) {
+				case string:
+					input = t.Input.(string)
+				case map[string]interface{}:
+					inputByteArray, err := json.Marshal(t.Input)
+					if err != nil {
+						return []error{err}
+					}
+					input = string(inputByteArray)
+				default:
+					fmt.Printf("Unexpected type: %T", inputType)
+					//err = errors.New("Unexpected type: %T", inputType)
+					//return []error{err}
+				}
+
 				Debugf("Input before replacement: %s", input)
 				r1 := strings.Trim(fmt.Sprintf("%v", lastResults[0]), "\"")
 				r2 := strings.Trim(fmt.Sprintf("%v", lastResults[1]), "\"")


### PR DESCRIPTION
**What?**

Allow test inputs to be either full arbitrary JSON, or stringified JSON, as test authors prefer.

In 88a4f926423be8bed0acf860f18594ffb7ba6cb8 we expand `examples/sample/test/*.json`'s inputs into full JSON to show this working, in particular on CI.

**Why?**

This allows for more readable test inputs in rather complex inputs, like those in [some Trust Exchange tests](https://github.com/CoMakery/teh/blob/50ff1621db02dc80a0942f97ea7b2c38f865974b/test/trust_atom_test.json#L14-L58).

