### PR TITLE
Dockerfile improvement and a new Dockerfile for development use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV GOPATH /golang
 ENV PATH $GOPATH/bin:/usr/local/go/bin:$PATH
 
 RUN go get -v -u github.com/whyrusleeping/gx
-RUN rm $GOPATH/src/github.com/ethereum/go-ethereum/tests -r
+RUN rm $GOPATH/src/github.com/ethereum/go-ethereum/tests -rf
 
 RUN  go get -v -d github.com/metacurrency/holochain
 

--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -1,0 +1,49 @@
+FROM golang:1.7.5-alpine
+MAINTAINER Gerry Gleason
+
+RUN apk add --update \
+      ca-certificates \
+      curl wget \
+      curl-dev \
+      procps \
+      openrc \
+      git \ 
+      make \
+    && rm -rf /var/cache/apk/* \
+    \
+    && addgroup holochain -g 868 \
+    && adduser -g 'Standard holochain user.' -u 868 -G holochain -h /home/holochain -s /bin/sh -D holochain \
+    && mkdir -p ~holochain/.ssh \
+    && chmod 700 ~holochain/.ssh \
+    && mv /etc/profile.d/color_prompt /etc/profile.d/color_prompt.sh \
+    && sed -i -e 's#/bin/ash#/bin/sh#' /etc/passwd \
+    && mkdir -p /work/bin /work/golang \
+    \
+    && touch /etc/holochain.env_vars \
+    && echo 'export GOPATH=/work/golang' >> /etc/holochain.env_vars \
+    && echo 'export GOBIN=/home/holochain/bin' >> /etc/holochain.env_vars \
+    && echo 'export PATH=$GOPATH/bin:/usr/local/go/bin:$GOBIN:$PATH' >> /etc/holochain.env_vars \
+    && cat /etc/holochain.env_vars \
+    && chown -R holochain /work \
+    && su holochain -c 'source /etc/holochain.env_vars; \
+      go get -v -u github.com/whyrusleeping/gx \
+      && go get -v -d github.com/metacurrency/holochain \
+      && cd /work/golang/src/github.com/metacurrency/holochain \
+      && make deps'
+
+WORKDIR /work/golang/src/github.com/metacurrency/holochain
+
+# above should get cached, does not depend on source
+ADD . /work/holochain 
+
+RUN rm -rf /work/golang/src/github.com/metacurrency/holochain/* \
+    && cp -pr /work/holochain/* /work/golang/src/github.com/metacurrency/holochain/ \
+    && chown -R holochain /work \
+    && su holochain -c 'source /etc/holochain.env_vars; pwd; ls -tlr; make; make bs'
+
+CMD ["su", "holochain", "-c", "source /etc/holochain.env_vars; make test" ]
+
+#CMD ["/bin/sh"]
+
+
+

--- a/Dockerfile.developer
+++ b/Dockerfile.developer
@@ -1,0 +1,52 @@
+FROM golang:1.7.5-alpine
+MAINTAINER Gerry Gleason
+
+WORKDIR /work
+
+  RUN apk add --update \
+      ca-certificates \
+      curl wget \
+      curl-dev \
+      procps \
+      openrc \
+      git \ 
+      make \
+    && rm -rf /var/cache/apk/* \
+    \
+    && addgroup developer -g 868 \
+    && adduser -g 'Standard developer user.' -u 868 -G developer -h /home/developer -s /bin/sh -D developer \
+    && mkdir -p ~developer/.ssh \
+    && touch /tmp/id_rsa.developer  \
+    && mv /tmp/id_rsa.developer ~developer/.ssh/id_rsa \
+    && chown -R developer. ~developer/ /work \ 
+    && chmod 700 ~developer/.ssh \
+    && chmod 600 ~developer/.ssh/id_rsa \
+    && mv /etc/profile.d/color_prompt /etc/profile.d/color_prompt.sh \
+    && sed -i -e 's#/bin/ash#/bin/sh#' /etc/passwd \
+    && touch /etc/developer.env_vars \
+    && mkdir /apps \
+    && ln -s /home/developer/holochain /apps/holochain \
+    && mkdir /home/developer/golang \
+    && mkdir /home/developer/bin \
+    && chown developer ~developer/golang ~developer/bin; \
+    \
+    echo 'export GOPATH=/work/golang' >> /etc/developer.env_vars; \
+    echo 'export GOBIN=/home/developer/bin' >> /etc/developer.env_vars; \
+    echo 'export PATH=$GOPATH/bin:/usr/local/go/bin:$GOBIN:$PATH' >> /etc/developer.env_vars; \
+    su - developer -c 'source /etc/developer.env_vars; \
+    git clone https://github.com/metacurrency/holochain ~developer/holochain \
+    && go get -v -u github.com/whyrusleeping/gx \
+    && go get -v -u github.com/metacurrency/holochain; \
+    cd ~developer/holochain \
+    && (make; true) && make bs'
+
+# note that on xhyve (MacOs and Windows), volume access can be slow
+VOLUME /home
+
+# run tests in a container:
+# docker run -t holochain:developer su - developer -c "source /etc/developer.env_vars; cd ~developer/holochain; time go get -t; time go test -v ./... || exit 1"
+
+##CMD ["/usr/bin/node", "/var/www/app.js"]
+#
+CMD ["/bin/sh"]
+

--- a/examples/clutter/Dockerfile.developer
+++ b/examples/clutter/Dockerfile.developer
@@ -42,6 +42,9 @@ WORKDIR /work
 
 # note that on xhyve (MacOs and Windows), volume access can be slow
 VOLUME /home
+# If you do have it on a volume, but not one exported from xhyve, you can bind mount and
+# backup data from a container's volume like this:
+#sudo docker run --rm --volumes-from my_container -v ~/container_backups/:/backup busybox tar cvzf /backup/contentservices_back.tgz home/webapp
 
 # run tests in a container:
 # docker run -t holochain:developer su - developer -c "source /etc/developer.env_vars; cd ~developer/holochain; time go get -t; time go test -v ./... || exit 1"
@@ -49,4 +52,3 @@ VOLUME /home
 ##CMD ["/usr/bin/node", "/var/www/app.js"]
 #
 CMD ["/bin/sh"]
-


### PR DESCRIPTION
We've been doing docker at work for a while now, and just noticed the Dockerfile and tried it out. We're mostly centos for our base, but out ops guy on the docker projects wants smaller images and like alpine. I found that the registry has lots of base image tags for golang as a base, including alpine.

You can see that the package list is pretty short, and go works in the base already. This image create a user, and a volume for home directories. When you don't have an existing volume persisted, you get what was in the mount point when it does the VOLUME command in the Dockerfile. We have the git repo for holochain checked out the ~developer and linked to /apps/holochain.

This style of Dockerfile the creates few image layers is preferred by a lot of docker devs now. This image builds in about 6 minutes as compared with almost 30 for the original ubuntu based image. It is also more than 45% smaller (700MB vs. 1.3G)

BTW, do we want to push images to dockerhub and build/test them at semaphore? I had that working once for wagn (http://wagn.org/)