### PR TITLE
Dockerfile mods to make sudo usable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,14 @@ RUN apk add --update \
       openrc \
       git \ 
       make \
+      sudo \
     && rm -rf /var/cache/apk/* \
+    && chmod +s /usr/bin/passwd \
     && addgroup holochain -g 868 \
     && adduser -G holochain -u 868 -D holochain \
+    && sed -i~orig -e'/wheel/s/$/,holochain/' /etc/group \
+    && passwd -u holochain \
+    && sed -i~orig -e'/ALL) ALL/s/# %wheel/%wheel/' /etc/sudoers \
     && mv /etc/profile.d/color_prompt /etc/profile.d/color_prompt.sh
 
 ENV GOPATH=/app/golang


### PR DESCRIPTION
This mod will give the holochain user sudo privilege (with password). The holochain password is unlocked but not set, so the user will have to create an acceptable password to use sudo.

Disable it by leaving out the sed that add holochain to the wheel group. You'd have to configure some specific commands or something in sudoers to use that. I think we should probably commit this with the wheel group line in a comment describing where to add it.