### PR TITLE
Make change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
   - 1.8
 
 script:
-  - TEST_FLAGS='-v -coverprofile=coverage.txt -covermode=atomic' make -e test
+  - TEST_FLAGS='-v -coverprofile=$(pkg_path)/coverage.txt -covermode=atomic' make -e test
   - make test-sample
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,9 @@ language: go
 go:
   - 1.8
 
-install:
-  - make hc && hc init node@example.com
-
 script:
-  - make work && go test -v -coverprofile=coverage.txt -covermode=atomic && go test -v ./... && make pub
-  - hc --debug --verbose clone --force examples/sample examples-sample && hc --debug --verbose test examples-sample
+  - TEST_FLAGS='-v -coverprofile=coverage.txt -covermode=atomic' make -e test
+  - make test-sample
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/Makefile
+++ b/Makefile
@@ -32,8 +32,9 @@ bs: deps
 	go get $(REPO)/cmd/bs
 	gx-go rewrite --undo
 test: deps
-	go get -t $(REPO)
-	go test $(TEST_FLAGS) ./...
+	go get -d -t $(REPO) && go test $(TEST_FLAGS) $(REPO)
+	go get -d -t $(REPO)/cmd/hc && go test $(TEST_FLAGS) $(REPO)/cmd/hc
+	go get -d -t $(REPO)/cmd/bs && go test $(TEST_FLAGS) $(REPO)/cmd/bs
 	gx-go rewrite --undo
 test-sample: hc
 # Init if not already init-ed

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GOBIN = $(value GOPATH)/bin
-.PHONY: test testcore testexamples testall init deps gx work pub
+.PHONY: test test-sample deps gx work pub
 # Anything which requires deps should end with: gx-go rewrite --undo
 
 hc: deps
@@ -8,22 +8,13 @@ hc: deps
 bs: deps
 	go install ./cmd/bs
 	gx-go rewrite --undo
-init: hc
-	hc init node@example.com
-test: testcore
-	gx-go rewrite --undo
-
-# NOTE: testall also runs the holochain tests in the examples and is intended to be
-# run from a system that has never initialized holochain, specifically the CI server
-# it will fail if you run it on your machine after once having run 'hc init'
-testall: testcore hc init testexamples
-	gx-go rewrite --undo
-testcore: deps
+test: deps
 	go get -t
 	go test -v ./...||exit 1
-testexamples: deps hc
-#	hc --debug --verbose clone --force examples/chat   examples-chat   && hc --debug --verbose test examples-chat
-	hc --debug --verbose clone --force examples/sample examples-sample && hc --debug --verbose test examples-sample
+	gx-go rewrite --undo
+test-sample: hc
+	hc --debug --verbose clone --force examples/sample examples-sample
+	hc --debug --verbose test examples-sample
 deps: gx
 	gx-go rewrite
 	go get -d ./...

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 GOBIN = $(value GOPATH)/bin
+REPO = $(CURDIR:$(GOPATH)/src/%=%)
+# Remove a $(GOPATH)/src/ from the beginning of the current directory.
+# Likely to be github.com/metacurrency/holochain
 
 ifndef HOME
 # Is probably a windows machine
@@ -13,17 +16,17 @@ endif
 HOLOPATH ?= $(HOME)/.holochain
 # Default .holochain location
 
-.PHONY: test test-sample deps gx work pub
+.PHONY: test test-sample deps work pub
 # Anything which requires deps should end with: gx-go rewrite --undo
 
 hc: deps
-	go install ./cmd/hc
+	go get $(REPO)/cmd/hc
 	gx-go rewrite --undo
 bs: deps
-	go install ./cmd/bs
+	go get $(REPO)/cmd/bs
 	gx-go rewrite --undo
 test: deps
-	go get -t
+	go get -t $(REPO)
 	go test -v ./...||exit 1
 	gx-go rewrite --undo
 test-sample: hc
@@ -38,11 +41,8 @@ $(strip $(wildcard $(HOLOPATH)/agent.txt)))' ''
 endif
 	hc --debug --verbose clone --force examples/sample examples-sample
 	hc --debug --verbose test examples-sample
-deps: gx
-	gx-go rewrite
-	go get -d ./...
-gx: $(GOBIN)/gx $(GOBIN)/gx-go
-	gx install --global
+deps: $(GOBIN)/gx $(GOBIN)/gx-go
+	gx-go get $(REPO)
 $(GOBIN)/gx:
 	go get -u github.com/whyrusleeping/gx
 $(GOBIN)/gx-go:

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,9 @@ REPO = $(CURDIR:$(GOPATH)/src/%=%)
 # Remove a $(GOPATH)/src/ from the beginning of the current directory.
 # Likely to be github.com/metacurrency/holochain
 
+go_packages = . $(wildcard ./cmd/*)
+# List of directories containing go packages
+
 ifndef HOME
 # Is probably a windows machine
 ifdef USERPROFILE
@@ -22,6 +25,11 @@ HOLOPATH ?= $(HOME)/.holochain
 
 TEST_FLAGS = -v
 
+define new_line
+
+
+endef
+
 .PHONY: hc bs test test-sample deps work pub
 # Anything which requires deps should end with: gx-go rewrite --undo
 
@@ -32,9 +40,7 @@ bs: deps
 	go get $(REPO)/cmd/bs
 	gx-go rewrite --undo
 test: deps
-	go get -d -t $(REPO) && go test $(TEST_FLAGS) $(REPO)
-	go get -d -t $(REPO)/cmd/hc && go test $(TEST_FLAGS) $(REPO)/cmd/hc
-	go get -d -t $(REPO)/cmd/bs && go test $(TEST_FLAGS) $(REPO)/cmd/bs
+	$(foreach pkg_path,$(go_packages),go get -d -t $(pkg_path) && go test $(TEST_FLAGS) $(pkg_path)${new_line})
 	gx-go rewrite --undo
 test-sample: hc
 # Init if not already init-ed

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,7 @@
+ifndef GOPATH
+$(error GOPATH *must* be defined)
+endif
+
 GOBIN = $(value GOPATH)/bin
 REPO = $(CURDIR:$(GOPATH)/src/%=%)
 # Remove a $(GOPATH)/src/ from the beginning of the current directory.
@@ -16,7 +20,9 @@ endif
 HOLOPATH ?= $(HOME)/.holochain
 # Default .holochain location
 
-.PHONY: test test-sample deps work pub
+TEST_FLAGS = -v
+
+.PHONY: hc bs test test-sample deps work pub
 # Anything which requires deps should end with: gx-go rewrite --undo
 
 hc: deps
@@ -27,7 +33,7 @@ bs: deps
 	gx-go rewrite --undo
 test: deps
 	go get -t $(REPO)
-	go test -v ./...||exit 1
+	go test $(TEST_FLAGS) ./...
 	gx-go rewrite --undo
 test-sample: hc
 # Init if not already init-ed
@@ -39,6 +45,7 @@ $(strip $(wildcard $(HOLOPATH)/agent.txt)))' ''
 	$(warning hc not init-ed. using bogus email.)
 	hc init node@example.com
 endif
+	$(if $(strip $(wildcard $(HOLOPATH)/examples-sample)),$(warning overwriting existing holochain 'examples-sample'))
 	hc --debug --verbose clone --force examples/sample examples-sample
 	hc --debug --verbose test examples-sample
 deps: $(GOBIN)/gx $(GOBIN)/gx-go

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,18 @@
 GOBIN = $(value GOPATH)/bin
+
+ifndef HOME
+# Is probably a windows machine
+ifdef USERPROFILE
+HOME = $(USERPROFILE)
+# Windows variable for home is USERPROFILE
+else
+$(error unable to get home directory)
+endif
+endif
+
+HOLOPATH ?= $(HOME)/.holochain
+# Default .holochain location
+
 .PHONY: test test-sample deps gx work pub
 # Anything which requires deps should end with: gx-go rewrite --undo
 
@@ -13,6 +27,15 @@ test: deps
 	go test -v ./...||exit 1
 	gx-go rewrite --undo
 test-sample: hc
+# Init if not already init-ed
+ifeq '$(and \
+$(strip $(wildcard $(HOLOPATH))),\
+$(strip $(wildcard $(HOLOPATH)/system.conf)),\
+$(strip $(wildcard $(HOLOPATH)/agent.txt)))' ''
+# If they all existed, the output of $(and) would be != ''
+	$(warning hc not init-ed. using bogus email.)
+	hc init node@example.com
+endif
 	hc --debug --verbose clone --force examples/sample examples-sample
 	hc --debug --verbose test examples-sample
 deps: gx


### PR DESCRIPTION
In this branch I have:
- Switched to using a new way of building gx-go packages
- Added more corner case detection and error-handling
- Added the ability to control which flags `go test` uses
- Made the code less shell specific. After this PR, only shell feature used is `&&`.
- Fixed several mistakes.
- Automatically show coverage for commands.

I suggest looking at the individual commits to get a more useful diff.