### PR TITLE
added progenitor to DNA, #72

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	ic "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
+	"io"
 	"os"
 )
 
@@ -30,7 +31,7 @@ const (
 type Agent interface {
 	Name() AgentName
 	KeyType() KeytypeType
-	GenKeys() error
+	GenKeys(seed io.Reader) error
 	PrivKey() ic.PrivKey
 	PubKey() ic.PubKey
 	NodeID() (peer.ID, string, error)
@@ -57,9 +58,12 @@ func (a *LibP2PAgent) PubKey() ic.PubKey {
 	return a.priv.GetPublic()
 }
 
-func (a *LibP2PAgent) GenKeys() (err error) {
+func (a *LibP2PAgent) GenKeys(seed io.Reader) (err error) {
 	var priv ic.PrivKey
-	priv, _, err = ic.GenerateEd25519Key(rand.Reader)
+	if seed == nil {
+		seed = rand.Reader
+	}
+	priv, _, err = ic.GenerateEd25519Key(seed)
 	if err != nil {
 		return
 	}
@@ -83,7 +87,7 @@ func NewAgent(keyType KeytypeType, name AgentName) (agent Agent, err error) {
 		a := LibP2PAgent{
 			name: name,
 		}
-		err = a.GenKeys()
+		err = a.GenKeys(nil)
 		if err != nil {
 			return
 		}

--- a/examples/sample/dna/dna.toml
+++ b/examples/sample/dna/dna.toml
@@ -138,3 +138,7 @@ RequiresVersion = 12
 
 [DHTConfig]
   HashType = "sha2-256"
+
+[Progenitor]
+  Name = "Example Agent <example@example.com"
+  PubKey = [8, 1, 18, 32, 193, 43, 31, 148, 23, 249, 163, 154, 128, 25, 237, 167, 253, 63, 214, 220, 206, 131, 217, 74, 168, 30, 215, 237, 231, 160, 69, 89, 48, 17, 104, 210]

--- a/holochain_test.go
+++ b/holochain_test.go
@@ -39,6 +39,10 @@ func TestNewHolochain(t *testing.T) {
 		So(h.nodeID, ShouldEqual, nodeID)
 		So(h.nodeIDStr, ShouldEqual, nodeIDStr)
 		So(h.nodeIDStr, ShouldEqual, peer.IDB58Encode(h.nodeID))
+
+		So(h.Progenitor.Name, ShouldEqual, "Joe")
+		pk, _ := a.PubKey().Bytes()
+		So(string(h.Progenitor.PubKey), ShouldEqual, string(pk))
 	})
 	Convey("New with Zome should fill them", t, func() {
 		z := Zome{Name: "zySampleZome",
@@ -182,6 +186,10 @@ func TestCloneNew(t *testing.T) {
 
 		So(fileExists(h.rootPath+"/"+ChainTestDir+"/test_0.json"), ShouldBeTrue)
 
+		So(h.Progenitor.Name, ShouldEqual, "Herbert <h@bert.com>")
+		pk, _ := agent.PubKey().Bytes()
+		So(string(h.Progenitor.PubKey), ShouldEqual, string(pk))
+
 	})
 }
 
@@ -209,6 +217,11 @@ func TestCloneJoin(t *testing.T) {
 		So(fileExists(h.DNAPath()+"/zySampleZome/profile.json"), ShouldBeTrue)
 		So(fileExists(h.DNAPath()+"/properties_schema.json"), ShouldBeTrue)
 		So(fileExists(h.rootPath+"/"+ConfigFileName+".toml"), ShouldBeTrue)
+
+		So(h.Progenitor.Name, ShouldEqual, "Example Agent <example@example.com")
+		pk := []byte{8, 1, 18, 32, 193, 43, 31, 148, 23, 249, 163, 154, 128, 25, 237, 167, 253, 63, 214, 220, 206, 131, 217, 74, 168, 30, 215, 237, 231, 160, 69, 89, 48, 17, 104, 210}
+		So(string(h.Progenitor.PubKey), ShouldEqual, string(pk))
+
 	})
 }
 


### PR DESCRIPTION
Hey folks, here's progenitor for review.  It keeps the same progenitor if you are doing a Join, but changes the progenitor to your agent when you do a Clone.

@artbrock, one of the things to remember here is that the go part of the app generator will have to add in the public key to the progenitor when converting the JSON blob.