### PR TITLE
added testing of just one file #265

### DIFF
--- a/apptest.go
+++ b/apptest.go
@@ -386,6 +386,17 @@ func (h *Holochain) DoTest(name string, i int, t TestData, startTime time.Time, 
 // This function is useful only in the context of developing a holochain and will return
 // an error if the chain has already been started (i.e. has genesis entries)
 func (h *Holochain) Test() []error {
+	return h.test("")
+}
+
+// TestOne tests a single test file
+// This function is useful only in the context of developing a holochain and will return
+// an error if the chain has already been started (i.e. has genesis entries)
+func (h *Holochain) TestOne(one string) []error {
+	return h.test(one)
+}
+
+func (h *Holochain) test(one string) []error {
 
 	var err error
 	var errs []error
@@ -406,7 +417,9 @@ func (h *Holochain) Test() []error {
 	failed := h.config.Loggers.TestFailed
 
 	for name, ts := range tests {
-
+		if one != "" && name != one {
+			continue
+		}
 		info.p("========================================")
 		info.pf("Test: '%s' starting...", name)
 		info.p("========================================")

--- a/apptest_test.go
+++ b/apptest_test.go
@@ -73,3 +73,24 @@ func TestTest(t *testing.T) {
 		So(err.Error(), ShouldEqual, "bogus error")
 	})
 }
+
+func TestTestOne(t *testing.T) {
+	d, _, h := setupTestChain("test")
+	defer cleanupTestDir(d)
+	if os.Getenv("DEBUG") != "" {
+		h.config.Loggers.TestPassed.Enabled = false
+		h.config.Loggers.TestFailed.Enabled = false
+		h.config.Loggers.TestInfo.Enabled = false
+	}
+	Convey("it should validate on test data", t, func() {
+
+		ShouldLog(&h.config.Loggers.TestInfo, `========================================
+Test: 'test_0' starting...
+========================================
+Test 'test_0.0' t+0ms: { zySampleZome addEven 2 %h%   0s  false}
+`, func() {
+			err := h.TestOne("test_0")
+			So(err, ShouldBeNil)
+		})
+	})
+}

--- a/cmd/hcdev/hcdev.go
+++ b/cmd/hcdev/hcdev.go
@@ -51,9 +51,10 @@ func setupApp() (app *cli.App) {
 	}
 	app.Commands = []cli.Command{
 		{
-			Name:    "test",
-			Aliases: []string{"t"},
-			Usage:   "run chain's unit or scenario tests",
+			Name:      "test",
+			Aliases:   []string{"t"},
+			ArgsUsage: "no args run's all stand-alone | [test file prefix] | [scenario] [role]",
+			Usage:     "run chain's stand-alone or scenario tests",
 			Action: func(c *cli.Context) error {
 				var err error
 				var h *holo.Holochain
@@ -70,10 +71,12 @@ func setupApp() (app *cli.App) {
 					if err != nil {
 						return err
 					}
-				} else if len(args) != 0 {
-					return errors.New("test: expected 0 args or 2 (scenario and role)")
-				} else {
+				} else if len(args) == 1 {
+					errs = h.TestOne(args[0])
+				} else if len(args) == 0 {
 					errs = h.Test()
+				} else {
+					return errors.New("test: expected 0 args (run all stand-alone tests), 1 arg (a single stand-alone test) or 2 args (scenario and role)")
 				}
 
 				var s string
@@ -89,7 +92,7 @@ func setupApp() (app *cli.App) {
 		{
 			Name:      "web",
 			Aliases:   []string{"serve", "w"},
-			ArgsUsage: "holochain-name [port]",
+			ArgsUsage: "[port]",
 			Usage:     fmt.Sprintf("serve a chain to the web on localhost:<port> (defaults to %s)", defaultPort),
 			Action: func(c *cli.Context) error {
 				h, err := getHolochain(c, service)


### PR DESCRIPTION
6abe707ddb  (on https://github.com/metacurrency/holochain/tree/204-hcdev-cmd branch) adds the ability to run a single stand-alone test file to hcdev like this

hcdev test <file_prefix>

i.e. if you have a test file messages.json  you would run:

hcdev test messages

and it will run that single test.