### PR TITLE
fix to allow cloneExample to have 1 param

### DIFF
--- a/cmd/hcdev/hcdev.go
+++ b/cmd/hcdev/hcdev.go
@@ -33,8 +33,13 @@ var bridgeFromH, bridgeToH *holo.Holochain
 // TODO: move these into cmd module
 func makeErr(prefix string, text string, code int) error {
 	errText := fmt.Sprintf("%s: %s", prefix, text)
-	fmt.Printf("CLI Error: %s\n", errText)
-	return cli.NewExitError(errText, 1)
+
+	if os.Getenv("HCDEV_TESTING") != "" {
+		os.Setenv("HCDEV_TESTING_EXITERR", fmt.Sprintf("%d", code))
+		return errors.New(errText)
+	} else {
+		return cli.NewExitError(errText, 1)
+	}
 }
 
 func makeErrFromError(prefix string, err error, code int) error {
@@ -113,16 +118,29 @@ func setupApp() (app *cli.App) {
 					return makeErr("init", "current directory is an initialized app, apps shouldn't be nested", 1)
 				}
 
+				var name string
 				args := c.Args()
 				if len(args) != 1 {
-					return makeErr("init", "expecting app name as single argument", 1)
+					if cloneExample != "" {
+						name = cloneExample
+					} else {
+						return makeErr("init", "expecting app name as single argument", 1)
+					}
 				}
 
 				if (interactive && clonePath != "") || (interactive && scaffoldPath != "") || (clonePath != "" && scaffoldPath != "") {
 					return makeErr("init", " options are mutually exclusive, please choose just one.", 1)
 				}
-				name := args[0]
+				if name == "" {
+					name = args[0]
+				}
 				devPath = filepath.Join(devPath, name)
+
+				info, err := os.Stat(devPath)
+				if err == nil && info.Mode().IsDir() {
+					return makeErr("init", fmt.Sprintf("%s already exists", devPath), 1)
+				}
+
 				if clonePath != "" {
 					// build the app by cloning from another app
 					info, err := os.Stat(clonePath)
@@ -203,7 +221,7 @@ func setupApp() (app *cli.App) {
 					fmt.Printf("initialized empty application to %s with new UUID:%v\n", devPath, scaffold.DNA.UUID)
 				}
 
-				err := os.Chdir(devPath)
+				err = os.Chdir(devPath)
 				if err != nil {
 					return makeErrFromError("", err, 1)
 				}
@@ -431,12 +449,7 @@ func setupApp() (app *cli.App) {
 
 func main() {
 	app := setupApp()
-
-	err := app.Run(os.Args)
-	if err != nil {
-		fmt.Printf("Error: %v\n", err)
-		os.Exit(1)
-	}
+	app.Run(os.Args)
 }
 
 func getHolochain(c *cli.Context, service *holo.Service) (h *holo.Holochain, err error) {

--- a/cmd/hcdev/hcdev_test.go
+++ b/cmd/hcdev/hcdev_test.go
@@ -21,6 +21,7 @@ func TestSetupApp(t *testing.T) {
 }
 
 func TestInit(t *testing.T) {
+	os.Setenv("HCDEV_TESTING", "true")
 	tmpTestDir, err := ioutil.TempDir("", "holochain.testing.hcdev")
 	if err != nil {
 		panic(err)
@@ -59,17 +60,38 @@ func TestInit(t *testing.T) {
 		So(cmd.IsFile(filepath.Join(tmpTestDir, "bar", "ui", "foo.js")), ShouldBeTrue)
 	})
 
-	Convey("'init bar --cloneExample=clutter myClutter' should copy files from github", t, func() {
+	Convey("'init bar --cloneExample=clutter' should copy files from github", t, func() {
 		err = os.Chdir(tmpTestDir)
 		if err != nil {
 			panic(err)
 		}
 
-		os.Args = []string{"hcdev", "init", "-cloneExample=clutter", "myClutter"}
+		// it should clone with the same name as the repo
+		os.Args = []string{"hcdev", "init", "-cloneExample=clutter"}
+		err = app.Run(os.Args)
+		So(err, ShouldBeNil)
+		So(cmd.IsFile(filepath.Join(tmpTestDir, "clutter", "dna", "clutter", "clutter.js")), ShouldBeTrue)
 
+		// or with a specified name
+		err = os.Chdir(tmpTestDir)
+		if err != nil {
+			panic(err)
+		}
+		os.Args = []string{"hcdev", "init", "-cloneExample=clutter", "myClutter"}
 		err = app.Run(os.Args)
 		So(err, ShouldBeNil)
 		So(cmd.IsFile(filepath.Join(tmpTestDir, "myClutter", "dna", "clutter", "clutter.js")), ShouldBeTrue)
+
+		// but fail if the directory is already there
+		err = os.Chdir(tmpTestDir)
+		if err != nil {
+			panic(err)
+		}
+		os.Args = []string{"hcdev", "init", "-cloneExample=clutter"}
+		err = app.Run(os.Args)
+		So(err, ShouldNotBeNil)
+		So(os.Getenv("HCDEV_TESTING_EXITERR"), ShouldEqual, "1")
+
 	})
 
 }


### PR DESCRIPTION
hi folks, I've been really bothered that you have to type `hcdev init -cloneExample clutter clutter`  So this is a quick fix to allow the name parameter to be optional in the case of cloneExample and it just uses the example name as the name of the directory to initialize.

This fix also includes a check to make sure the devPath isn't already there, and fixes how testing works so that when testing error cases the app doesn't do an os.Exit() so we can actually keep the tests going, and still test those error conditions.

I realize this isn't quite in the sprint tickets, but I do think it's part of the sprint purpose.  So I welcome feedback on whether I shouldn't have actually done this work...  @lucksus  @christopherreay ?

(Please note that this branch is not off master, but one down from master because I think we should actually remove that last merge of the 279 branch into master)