### PR TITLE
debugging cleanup, fixes #363

### DIFF
--- a/action.go
+++ b/action.go
@@ -297,7 +297,7 @@ func (a *ActionDebug) Args() []Arg {
 }
 
 func (a *ActionDebug) Do(h *Holochain) (response interface{}, err error) {
-	h.Config.Loggers.App.p(a.msg)
+	h.Config.Loggers.App.Log(a.msg)
 	return
 }
 

--- a/apptest/apptest_test.go
+++ b/apptest/apptest_test.go
@@ -36,7 +36,10 @@ func TestTestStringReplacements(t *testing.T) {
 func TestTest(t *testing.T) {
 	d, _, h := SetupTestChain("test")
 	CleanupTestDir(filepath.Join(d, ".holochain", "test", "test")) // delete the test data created by gen dev
-	if os.Getenv("DEBUG") != "1" {
+
+	_, requested := DebuggingRequestedViaEnv()
+	// unless env indicates debugging, don't show the test results as this test of testing runs
+	if !requested {
 		h.Config.Loggers.TestPassed.Enabled = false
 		h.Config.Loggers.TestFailed.Enabled = false
 		h.Config.Loggers.TestInfo.Enabled = false
@@ -49,7 +52,10 @@ func TestTest(t *testing.T) {
 
 	d, _, h = SetupTestChain("test")
 	defer CleanupTestDir(d)
-	if os.Getenv("DEBUG") != "1" {
+
+	_, requested = DebuggingRequestedViaEnv()
+	// unless env indicates debugging, don't show the test results as this test of testing runs
+	if !requested {
 		h.Config.Loggers.TestPassed.Enabled = false
 		h.Config.Loggers.TestFailed.Enabled = false
 		h.Config.Loggers.TestInfo.Enabled = false

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -21,8 +21,6 @@ import (
 	holo "github.com/metacurrency/holochain"
 )
 
-var debug bool = false
-
 var ErrServiceUninitialized = errors.New("service not initialized, run 'hcdev init'")
 
 func GetCurrentDirectory() (dir string, err error) {
@@ -40,24 +38,21 @@ func ExecBinScript(script string, args ...string) (err error) {
 	if err != nil {
 		return
 	}
-	if debug {
-		fmt.Printf("HC: common.go: ExecBinScript: %v (%v)", path, args)
-	}
+
+	holo.Debugf("ExecBinScript: %v (%v)", path, args)
+
 	return syscallExec(path, args...)
 }
 
 func OsExecSilent(args ...string) error {
 	cmd := exec.Command(args[0], args[1:]...)
-	if debug {
-		fmt.Printf("common.go: OsExecSilent: %v", cmd)
-	}
+	holo.Debugf("OsExecSilent: %v", cmd)
+
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return err
 	}
-	if debug {
-		fmt.Printf("HC: common.go: OsExecSilent: %v", output)
-	}
+	holo.Debugf("OsExecSilent: %v", output)
 
 	return nil
 }
@@ -65,21 +60,15 @@ func OsExecSilent(args ...string) error {
 // OsExecPipes executes a command as if we are in a shell, including user input
 func OsExecPipes(args ...string) *exec.Cmd {
 	cmd := OsExecPipes_noRun(args...)
-
-	if debug {
-		fmt.Printf("HC: common.go: OsExecPipes: %v", cmd)
-	}
+	holo.Debugf("OsExecPipes: %v", cmd)
 	cmd.Run()
-
 	return cmd
 }
 
 // OsExecPipes executes a command as if we are in a shell, including user input
 func OsExecPipes_noRun(args ...string) *exec.Cmd {
 	cmd := exec.Command(args[0], args[1:]...)
-	if debug {
-		fmt.Printf("HC: common.go: OsExecPipes_noRun: %v", cmd)
-	}
+	holo.Debugf("OsExecPipes_noRun: %v", cmd)
 
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/cmd/hcdev/hcdev_test.go
+++ b/cmd/hcdev/hcdev_test.go
@@ -64,10 +64,8 @@ func TestRunScenarioTest(t *testing.T) {
 		So(err, ShouldBeNil)
 		//defer os.RemoveAll(execDir)  // can't delete because this stuff runs in the background...
 
-		os.Setenv("DEBUG", "true")
-
 		// setupTestingApp moved us into the app so we just need to point to  a working directory for the test (execDir)
-		testCommand := []string{"hcdev", "-debug", "-path", tmpTestDir + "/foo", "-execpath", execDir, "scenario", "sampleScenario"}
+		testCommand := []string{"hcdev", "-path", tmpTestDir + "/foo", "-execpath", execDir, "scenario", "sampleScenario"}
 
 		err = app.Run(testCommand)
 		So(err, ShouldBeNil)

--- a/log.go
+++ b/log.go
@@ -33,6 +33,7 @@ type Logger struct {
 }
 
 var colorMap map[string]*color.Color
+var EnableAllLoggersEnv string = "HC_ENABLE_ALL_LOGS"
 
 func (h *Logger) GetColor(colorName string) *color.Color {
 	if _, ok := colorMap["red"]; !ok {
@@ -100,7 +101,7 @@ func (l *Logger) New(w io.Writer) (err error) {
 		l.tf, l.f = l.setupTime(l.f)
 	}
 
-	d := os.Getenv("DEBUG")
+	d := os.Getenv(EnableAllLoggersEnv)
 	switch d {
 	case "1":
 		l.Enabled = true

--- a/log_test.go
+++ b/log_test.go
@@ -85,7 +85,24 @@ func TestNewLog(t *testing.T) {
 		l.SetPrefix("%{color:red}[COLOR PREFIX]")
 		l.Log("threefish")
 		So(buf.String(), ShouldEqual, "onefish\n[PREFIX]twofish\n\033[31m[COLOR PREFIX]\033[0mthreefish\n")
-
 	})
 
+	Convey("it should handle file name and line number", t, func() {
+		var buf bytes.Buffer
+		l := Logger{
+			Enabled: true,
+			Format:  "%{file}.%{line}:%{message}",
+		}
+		l.New(&buf)
+		doDebug(l, "fish")
+		So(buf.String(), ShouldEqual, "log_test.go.82:fish\n")
+	})
+
+}
+
+// we do this because in the case of file & line needs to know how many
+// calls back up the stack to use for calculating the line number and we
+// allways have a wrapper function around the log
+func doDebug(l Logger, m string) {
+	l.Log(m)
 }

--- a/log_test.go
+++ b/log_test.go
@@ -95,7 +95,7 @@ func TestNewLog(t *testing.T) {
 		}
 		l.New(&buf)
 		doDebug(l, "fish")
-		So(buf.String(), ShouldEqual, "log_test.go.82:fish\n")
+		So(buf.String(), ShouldEqual, "log_test.go.97:fish\n")
 	})
 
 }

--- a/service.go
+++ b/service.go
@@ -411,7 +411,7 @@ func (s *Service) load(name string, format string) (hP *Holochain, err error) {
 	if err != nil {
 		return
 	}
-	if err = h.setupConfig(); err != nil {
+	if err = h.SetupLogging(); err != nil {
 		return
 	}
 
@@ -536,11 +536,7 @@ func _makeConfig(s *Service) (config Config, err error) {
 		if err != nil {
 			return
 		}
-
-		if IsDebugging() {
-			fmt.Printf("HC: service.go: makeConfig: using environment variable to set port to:            %v\n", val)
-		}
-
+		Debugf("HC: service.go: makeConfig: using environment variable to set port to: %v\n", val)
 	}
 	val = os.Getenv("HOLOCHAINCONFIG_BOOTSTRAP")
 	if val != "" {
@@ -577,7 +573,7 @@ func makeConfig(h *Holochain, s *Service) (err error) {
 	if err = Encode(f, h.encodingFormat, &h.Config); err != nil {
 		return
 	}
-	if err = h.setupConfig(); err != nil {
+	if err = h.SetupLogging(); err != nil {
 		return
 	}
 	return
@@ -629,7 +625,7 @@ func (s *Service) GenDev(root string, encodingFormat string, initDB bool) (h *Ho
 			return
 		}
 
-		if err = h.setupConfig(); err != nil {
+		if err = h.SetupLogging(); err != nil {
 			return
 		}
 	}
@@ -850,10 +846,6 @@ func (s *Service) SaveDNAFile(root string, dna *DNA, encodingFormat string, over
 
 	err = Encode(f, encodingFormat, dnaFile)
 	return
-}
-
-func IsDebugging() bool {
-	return strings.ToLower(os.Getenv("DEBUG")) == "true" || os.Getenv("DEBUG") == "1"
 }
 
 // SaveScaffold writes out a holochain application based on scaffold file to path

--- a/service_test.go
+++ b/service_test.go
@@ -351,7 +351,7 @@ func TestMakeConfig(t *testing.T) {
 	Convey("make config should produce default config from OS env overridden values", t, func() {
 		os.Setenv("HOLOCHAINCONFIG_PORT", "12345")
 		os.Setenv("HOLOCHAINCONFIG_ENABLEMDNS", "true")
-		os.Setenv("HOLOCHAINCONFIG_LOGPREFIX", "prefix:%{color:cyan}")
+		os.Setenv("HCLOG_PREFIX", "prefix:%{color:cyan}")
 		os.Setenv("HOLOCHAINCONFIG_BOOTSTRAP", "_")
 		err := makeConfig(h, s)
 		So(err, ShouldBeNil)


### PR DESCRIPTION
This branch cleans up debugging so that we separate out app debugging from core debugging.  App debugging gets turned on with the -debug flag to the various commands, and core debugging gets turned on via setting the HCDEBUG environment variable. i.e. `HCDEBUG=1 hcdev web` is different from `hcdev -debug web`  

Turning on HCDEBUG activates the output of anything from `Debug()` or `Debugf()` calls.  Setting the `-debug` flag enables the DHT and Gossip logs in. 