### PR TITLE
hcadmin bridging, fixes #353

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ go:
   - 1.8
 
 script:
+  - make hcdev
   - TEST_FLAGS='-v -coverprofile=$(pkg_path)/coverage.txt -covermode=atomic' make -e test
   - make test-sample
 

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -21,7 +21,7 @@ import (
 	holo "github.com/metacurrency/holochain"
 )
 
-var ErrServiceUninitialized = errors.New("service not initialized, run 'hcdev init'")
+var ErrServiceUninitialized = errors.New("service not initialized, run 'hcadmin init'")
 
 func GetCurrentDirectory() (dir string, err error) {
 	dir, err = os.Getwd()

--- a/cmd/hcadmin/hcadmin.go
+++ b/cmd/hcadmin/hcadmin.go
@@ -201,7 +201,9 @@ func setupApp() (app *cli.App) {
 
 	app.Before = func(c *cli.Context) error {
 		if debug {
-			os.Setenv("DEBUG", "1")
+			os.Setenv("HCLOG_APP_ENABLE", "1")
+			os.Setenv("HCLOG_DHT_ENABLE", "1")
+			os.Setenv("HCLOG_GOSSIP_ENABLE", "1")
 		}
 		if verbose {
 			fmt.Printf("hcadmin version %s \n", app.Version)

--- a/cmd/hcadmin/hcadmin.go
+++ b/cmd/hcadmin/hcadmin.go
@@ -27,6 +27,7 @@ func setupApp() (app *cli.App) {
 	var dumpChain, dumpDHT bool
 	var root string
 	var service *holo.Service
+	var bridgeToAppData, bridgeFromAppData string
 
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{
@@ -138,6 +139,18 @@ func setupApp() (app *cli.App) {
 			Aliases:   []string{"j"},
 			ArgsUsage: "from-chain to-chain",
 			Usage:     "allows to-chain to make calls to functions in from-chain",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:        "bridgeToAppData",
+					Usage:       "application data to pass to the bridged to app",
+					Destination: &bridgeToAppData,
+				},
+				cli.StringFlag{
+					Name:        "bridgeFromAppData",
+					Usage:       "application data to pass to the bridging from app",
+					Destination: &bridgeFromAppData,
+				},
+			},
 			Action: func(c *cli.Context) error {
 				fromChain := c.Args().First()
 				if fromChain == "" {
@@ -157,12 +170,12 @@ func setupApp() (app *cli.App) {
 					return err
 				}
 
-				token, err := hTo.AddBridgeAsCallee(hFrom.DNAHash(), "")
+				token, err := hTo.AddBridgeAsCallee(hFrom.DNAHash(), bridgeToAppData)
 				if err != nil {
 					return err
 				}
 
-				err = hFrom.AddBridgeAsCaller(hTo.DNAHash(), token, fmt.Sprintf("http://localhost:%d", hTo.Config.Port), "")
+				err = hFrom.AddBridgeAsCaller(hTo.DNAHash(), token, fmt.Sprintf("http://localhost:%d", hTo.Config.Port), bridgeFromAppData)
 
 				if err == nil {
 					if verbose {

--- a/cmd/hcadmin/hcadmin_test.go
+++ b/cmd/hcadmin/hcadmin_test.go
@@ -1,9 +1,17 @@
 package main
 
 import (
+	"bytes"
+	"fmt"
+	holo "github.com/metacurrency/holochain"
+	cmd "github.com/metacurrency/holochain/cmd"
 	. "github.com/smartystreets/goconvey/convey"
-	_ "github.com/urfave/cli"
+	"github.com/urfave/cli"
+	"io"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestSetupApp(t *testing.T) {
@@ -11,4 +19,89 @@ func TestSetupApp(t *testing.T) {
 	Convey("it should create the cli App", t, func() {
 		So(app.Name, ShouldEqual, "hcadmin")
 	})
+}
+
+func TestInit(t *testing.T) {
+	d := holo.SetupTestDir()
+	defer os.RemoveAll(d)
+	app := setupApp()
+	Convey("before init it should return service not initialized error", t, func() {
+		os.Args = []string{"hadmin", "-path", d, "status"}
+		err := app.Run(os.Args)
+		So(err, ShouldEqual, cmd.ErrServiceUninitialized)
+	})
+	app = setupApp()
+	Convey("after init status should show no chains", t, func() {
+		out, err := runAppWithStdoutCapture(app, []string{"hcadmin", "-path", d, "init", "testing-identity"})
+		So(err, ShouldBeNil)
+		So(out, ShouldEqual, "Holochain service initialized\n")
+		app = setupApp()
+		out, err = runAppWithStdoutCapture(app, []string{"hcadmin", "-verbose", "-path", d, "status"})
+		So(err, ShouldBeNil)
+		So(out, ShouldEqual, fmt.Sprintf("hcadmin version %s \nno installed chains\n", app.Version))
+	})
+}
+
+func TestJoin(t *testing.T) {
+	d := holo.SetupTestDir()
+	defer os.RemoveAll(d)
+	app := setupApp()
+	os.Args = []string{"hadmin", "-path", d, "init", "test-identity"}
+	err := app.Run(os.Args)
+	if err != nil {
+		panic(err)
+	}
+	cmd.OsExecPipes("hcdev", "-path", d, "init", "-test", "testAppSrc")
+	app = setupApp()
+	Convey("it should join a chain", t, func() {
+		out, err := runAppWithStdoutCapture(app, []string{"hcadmin", "-verbose", "-path", d, "join", filepath.Join(d, "testAppSrc"), "testApp"})
+		So(err, ShouldBeNil)
+		So(out, ShouldContainSubstring, fmt.Sprintf("hcadmin version %s \n", app.Version))
+		So(out, ShouldContainSubstring, fmt.Sprintf("joined testApp from %s/testAppSrc", d))
+		So(out, ShouldContainSubstring, "Genesis entries added and DNA hashed for new holochain with ID:")
+	})
+	app = setupApp()
+	Convey("after join status should show it", t, func() {
+		out, err := runAppWithStdoutCapture(app, []string{"hcadmin", "-path", d, "status"})
+		So(err, ShouldBeNil)
+		So(out, ShouldContainSubstring, "installed holochains:     testApp Qm")
+	})
+	app = setupApp()
+	Convey("after join dump -chain should show it", t, func() {
+		out, err := runAppWithStdoutCapture(app, []string{"hcadmin", "-path", d, "dump", "-chain", "testApp"})
+		So(err, ShouldBeNil)
+		So(out, ShouldContainSubstring, "Chain for: Qm")
+	})
+	app = setupApp()
+	Convey("after join dump -dht should show it", t, func() {
+		out, err := runAppWithStdoutCapture(app, []string{"hcadmin", "-path", d, "dump", "-dht", "testApp"})
+		So(err, ShouldBeNil)
+		So(out, ShouldContainSubstring, "DHT for: Qm")
+		So(out, ShouldContainSubstring, "DHT changes:2")
+	})
+}
+
+func runAppWithStdoutCapture(app *cli.App, args []string) (out string, err error) {
+	os.Args = args
+
+	old := os.Stdout // keep backup of the real stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	go func() { err = app.Run(os.Args) }()
+	time.Sleep(time.Second / 2)
+
+	outC := make(chan string)
+	// copy the output in a separate goroutine so printing can't block indefinitely
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		outC <- buf.String()
+	}()
+
+	// back to normal state
+	w.Close()
+	os.Stdout = old // restoring the real stdout
+	out = <-outC
+	return
 }

--- a/service.go
+++ b/service.go
@@ -764,7 +764,6 @@ func (s *Service) GenChain(name string) (h *Holochain, err error) {
 
 // List chains produces a textual representation of the chains in the .holochain directory
 func (s *Service) ListChains() (list string) {
-
 	chains, _ := s.ConfiguredChains()
 	l := len(chains)
 	if l > 0 {
@@ -775,7 +774,7 @@ func (s *Service) ListChains() (list string) {
 			i++
 		}
 		sort.Strings(keys)
-		list = "installed holochains: "
+		list = "installed holochains:\n"
 		for _, k := range keys {
 			id := chains[k].DNAHash()
 			var sid = "<not-started>"
@@ -783,6 +782,16 @@ func (s *Service) ListChains() (list string) {
 				sid = id.String()
 			}
 			list += fmt.Sprintf("    %v %v\n", k, sid)
+			bridges, _ := chains[k].GetBridges()
+			if bridges != nil {
+				for _, b := range bridges {
+					if b.Side == BridgeTo {
+						list += fmt.Sprintf("        bridged to: %v\n", b.ToApp)
+					} else {
+						list += fmt.Sprintf("        bridged from by token: %v\n", b.FromToken)
+					}
+				}
+			}
 		}
 
 	} else {
@@ -1561,7 +1570,7 @@ function receive(from,message) {
 (defn validateDelPkg [entryType] nil)
 (defn validateLinkPkg [entryType] nil)
 (defn genesis [] true)
-(defn bridgeGenesis [side app data] (begin (debug (concat "bridge genesis " (cond (== side HC_Bridge_From) "from" "to") ": other side is:" app " bridging data:" data))  true))
+(defn bridgeGenesis [side app data] (begin (debug (concat "bridge genesis " (cond (== side HC_Bridge_From) "from" "to") "-- other side is:" app " bridging data:" data))  true))
 (defn receive [from message]
 	(hash pong: (hget message %ping)))
 `

--- a/service_test.go
+++ b/service_test.go
@@ -98,14 +98,14 @@ func TestServiceGenChain(t *testing.T) {
 
 	Convey("it should return a list of the chains", t, func() {
 		list := s.ListChains()
-		So(list, ShouldEqual, "installed holochains:     test <not-started>\n")
+		So(list, ShouldEqual, "installed holochains:\n    test <not-started>\n")
 	})
 	Convey("it should start a chain and return a holochain object", t, func() {
 		h2, err := s.GenChain("test")
 		So(err, ShouldBeNil)
 		So(h2.nucleus.dna.UUID, ShouldEqual, h.nucleus.dna.UUID)
 		list := s.ListChains()
-		So(list, ShouldEqual, fmt.Sprintf("installed holochains:     test %v\n", h2.dnaHash))
+		So(list, ShouldEqual, fmt.Sprintf("installed holochains:\n    test %v\n", h2.dnaHash))
 	})
 }
 


### PR DESCRIPTION
with these changes `hcadmin status` displays bridge status for apps, and also allows you to specify bridging data when creating a bridge.

this branch also adds a bunch of tests for hcadmin for which there were none before.

@rasikachafekar  and @jackThammer, in your review please confirm that these changes allow actually running your bridging apps using hcadmin instead of hcdev.