### PR TITLE
during dev you can now specify BridgeTo by name, resolves #369

### DIFF
--- a/cmd/common_test.go
+++ b/cmd/common_test.go
@@ -13,14 +13,14 @@ import (
 )
 
 func TestIsAppDir(t *testing.T) {
-	
+
 	for _, configExtension := range GetConfigExtensionList() {
 		Convey(fmt.Sprintf("it should test to see if dir is a holochain app (%v)", configExtension), t, func() {
 
 			d, s := holo.SetupTestService()
-			
+
 			So(IsAppDir(d).Error(), ShouldEqual, "HC: Holochain App directory missing dna/dna.xyz config file")
-			h, err := s.GenDev(filepath.Join(s.Path, "test"), configExtension, true)
+			h, err := s.MakeTestingApp(filepath.Join(s.Path, "test"), configExtension, true)
 			if err != nil {
 				panic(err)
 			}

--- a/cmd/hc/hc.go
+++ b/cmd/hc/hc.go
@@ -114,7 +114,7 @@ func setupApp() (app *cli.App) {
 					return err
 				}
 
-				err = service.Clone(srcPath, root+"/"+name, agent, holo.CloneWithNewUUID, holo.InitializeDB)
+				_, err = service.Clone(srcPath, root+"/"+name, agent, holo.CloneWithNewUUID, holo.InitializeDB)
 				if err == nil {
 					if verbose {
 						h, err := service.Load(name)
@@ -344,7 +344,7 @@ func setupApp() (app *cli.App) {
 				if err != nil {
 					return err
 				}
-				err = service.Clone(srcPath, root+"/"+name, agent, holo.CloneWithSameUUID, holo.InitializeDB)
+				_, err = service.Clone(srcPath, root+"/"+name, agent, holo.CloneWithSameUUID, holo.InitializeDB)
 				if err == nil {
 					if verbose {
 						fmt.Printf("joined %s from %s\n", name, srcPath)
@@ -430,7 +430,7 @@ func setupApp() (app *cli.App) {
 						return e
 					}
 				}
-				h, err := service.GenDev(root+"/"+name, format, holo.InitializeDB)
+				h, err := service.MakeTestingApp(root+"/"+name, format, holo.InitializeDB)
 				if err == nil {
 					if verbose {
 						fmt.Printf("created %s with new uuid: %v\n", name, h.Nucleus().DNA().UUID)

--- a/cmd/hcadmin/hcadmin.go
+++ b/cmd/hcadmin/hcadmin.go
@@ -124,7 +124,7 @@ func setupApp() (app *cli.App) {
 				if err != nil {
 					return err
 				}
-				err = service.Clone(srcPath, filepath.Join(root, name), agent, holo.CloneWithSameUUID, holo.InitializeDB)
+				_, err = service.Clone(srcPath, filepath.Join(root, name), agent, holo.CloneWithSameUUID, holo.InitializeDB)
 				if err == nil {
 					if verbose {
 						fmt.Printf("joined %s from %s\n", name, srcPath)

--- a/cmd/hcd/hcd_test.go
+++ b/cmd/hcd/hcd_test.go
@@ -39,7 +39,7 @@ func TestWeb(t *testing.T) {
 		panic(err)
 	}
 	root := filepath.Join(s.Path, "testApp")
-	h, err := s.GenDev(root, "json", holo.InitializeDB)
+	h, err := s.MakeTestingApp(root, "json", holo.InitializeDB)
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/hcdev/hcdev.go
+++ b/cmd/hcdev/hcdev.go
@@ -232,7 +232,7 @@ func setupApp() (app *cli.App) {
 
 						}
 					}
-					_, err := service.GenDev(devPath, "json", holo.SkipInitializeDB)
+					_, err := service.MakeTestingApp(devPath, "json", holo.SkipInitializeDB)
 					if err != nil {
 						return cmd.MakeErrFromErr(c, err)
 					}
@@ -647,6 +647,7 @@ func setupApp() (app *cli.App) {
 	}
 
 	app.Before = func(c *cli.Context) error {
+		holo.IsDevMode = true
 		lastRunContext = c
 
 		var err error
@@ -767,22 +768,13 @@ func main() {
 }
 
 func getHolochain(c *cli.Context, service *holo.Service) (h *holo.Holochain, bridgeApps []holo.BridgeApp, err error) {
-	fmt.Printf("Copying chain to: %s\n", rootPath)
+	// clear out the previous chain data that was copied from the last test/run
 	err = os.RemoveAll(filepath.Join(rootPath, name))
 	if err != nil {
 		return
 	}
 	var agent holo.Agent
 	agent, err = holo.LoadAgent(rootPath)
-	if err != nil {
-		return
-	}
-	err = service.Clone(devPath, filepath.Join(rootPath, name), agent, holo.CloneWithSameUUID, holo.InitializeDB)
-	if err != nil {
-		return
-	}
-
-	h, err = service.Load(name)
 	if err != nil {
 		return
 	}
@@ -799,7 +791,7 @@ func getHolochain(c *cli.Context, service *holo.Service) (h *holo.Holochain, bri
 	}
 
 	if bridgeToPath != "" {
-		bridgeToH, err = bridge(service, h, agent, bridgeToPath, holo.BridgeFrom)
+		bridgeToH, err = setupBridgeApp(service, h, agent, bridgeToPath, holo.BridgeFrom)
 		if err != nil {
 			return
 		}
@@ -812,7 +804,7 @@ func getHolochain(c *cli.Context, service *holo.Service) (h *holo.Holochain, bri
 				Port:                  bridgeToPort})
 	}
 	if bridgeFromPath != "" {
-		bridgeFromH, err = bridge(service, h, agent, bridgeFromPath, holo.BridgeTo)
+		bridgeFromH, err = setupBridgeApp(service, h, agent, bridgeFromPath, holo.BridgeTo)
 		if err != nil {
 			return
 		}
@@ -824,10 +816,22 @@ func getHolochain(c *cli.Context, service *holo.Service) (h *holo.Holochain, bri
 				BridgeGenesisDataTo:   bridgeToAppData,
 				Port:                  bridgeFromPort})
 	}
+
+	fmt.Printf("Copying chain to: %s\n", rootPath)
+	_, err = service.Clone(devPath, filepath.Join(rootPath, name), agent, holo.CloneWithSameUUID, holo.InitializeDB)
+	if err != nil {
+		return
+	}
+
+	h, err = service.Load(name)
+	if err != nil {
+		return
+	}
 	return
 }
 
-func bridge(service *holo.Service, h *holo.Holochain, agent holo.Agent, path string, side int) (bridgeH *holo.Holochain, err error) {
+// setupBridgeApp clones the bridge app from source and loads it in preparation for actual bridging
+func setupBridgeApp(service *holo.Service, h *holo.Holochain, agent holo.Agent, path string, side int) (bridgeH *holo.Holochain, err error) {
 
 	bridgeName := filepath.Base(path)
 
@@ -844,7 +848,7 @@ func bridge(service *holo.Service, h *holo.Holochain, agent holo.Agent, path str
 	if err != nil {
 		return
 	}
-	err = service.Clone(path, filepath.Join(rootPath, bridgeName), agent, holo.CloneWithSameUUID, holo.InitializeDB)
+	_, err = service.Clone(path, filepath.Join(rootPath, bridgeName), agent, holo.CloneWithSameUUID, holo.InitializeDB)
 	if err != nil {
 		return
 	}
@@ -853,6 +857,17 @@ func bridge(service *holo.Service, h *holo.Holochain, agent holo.Agent, path str
 	if err != nil {
 		return
 	}
+
+	// set the dna for use by the dev BridgeTo resolver
+	var DNAHash holo.Hash
+	DNAHash, err = holo.DNAHashofUngenedChain(bridgeH)
+	if err != nil {
+		return
+	}
+	os.Setenv("HCDEV_DNA_FOR_"+bridgeName, DNAHash.String())
+
+	// clear the log prefix for the next load.
+	os.Setenv("HCLOG_PREFIX", "")
 	return
 }
 
@@ -882,7 +897,7 @@ func doClone(s *holo.Service, clonePath, devPath string) (err error) {
 		return
 	}
 
-	err = s.Clone(clonePath, devPath, agent, holo.CloneWithSameUUID, holo.SkipInitializeDB)
+	_, err = s.Clone(clonePath, devPath, agent, holo.CloneWithSameUUID, holo.SkipInitializeDB)
 	if err != nil {
 		return
 	}

--- a/cmd/hcdev/hcdev.go
+++ b/cmd/hcdev/hcdev.go
@@ -864,7 +864,8 @@ func setupBridgeApp(service *holo.Service, h *holo.Holochain, agent holo.Agent, 
 	if err != nil {
 		return
 	}
-	os.Setenv("HCDEV_DNA_FOR_"+bridgeName, DNAHash.String())
+	holo.DevDNAResolveMap = make(map[string]string)
+	holo.DevDNAResolveMap[bridgeName] = DNAHash.String()
 
 	// clear the log prefix for the next load.
 	os.Setenv("HCLOG_PREFIX", "")

--- a/holochain.go
+++ b/holochain.go
@@ -388,8 +388,7 @@ func (h *Holochain) AddAgentEntry(revocation Revocation) (headerHash, agentHash 
 }
 
 // GenChain establishes a holochain instance by creating the initial genesis entries in the chain
-// It assumes a properly set up .holochain sub-directory with a config file and
-// keys for signing.  See GenDev()
+// It assumes a properly set up .holochain sub-directory with a config file and keys for signing.
 func (h *Holochain) GenChain() (headerHash Hash, err error) {
 
 	if h.Started() {

--- a/holochain_test.go
+++ b/holochain_test.go
@@ -203,7 +203,7 @@ func TestNewEntry(t *testing.T) {
 	defer CleanupTestDir(d)
 	n := "test"
 	path := filepath.Join(s.Path, n)
-	h, err := s.GenDev(path, "toml", InitializeDB)
+	h, err := s.MakeTestingApp(path, "toml", InitializeDB)
 	if err != nil {
 		panic(err)
 	}

--- a/jsribosome_test.go
+++ b/jsribosome_test.go
@@ -246,7 +246,7 @@ func TestNewJSRibosome(t *testing.T) {
 				d, s, h := PrepareTestChain("test")
 				defer CleanupTestDir(d)
 
-				h2, err := s.GenDev(filepath.Join(s.Path, "test2"), "json")
+				h2, err := s.MakeTestingApp(filepath.Join(s.Path, "test2"), "json")
 				if err != nil {
 					panic(err)
 				}

--- a/service.go
+++ b/service.go
@@ -136,8 +136,9 @@ type TestData struct {
 
 // IsDevMode is used to enable certain functionality when developing holochains, for example,
 // in dev mode, you can put the name of an app in the BridgeTo of the DNA and it will get
-// resolved to DNA hash of the app in the "HCDEV_DNA_FOR_<name> env variable.
+// resolved to DNA hash of the app in the DevDNAResolveMap[name] global variable.
 var IsDevMode bool = false
+var DevDNAResolveMap map[string]string
 
 // IsInitialized checks a path for a correctly set up .holochain directory
 func IsInitialized(root string) bool {
@@ -365,10 +366,12 @@ func (s *Service) loadDNA(path string, filename string, format string) (dnaP *DN
 			dna.Zomes[i].BridgeTo, err = NewHash(zome.BridgeTo)
 			if err != nil {
 				// if in dev mode assume the bridgeTo was the app name
-				// and that hcdev put the actual DNA for us in the env var
-				// so try again with that value
+				// and that hcdev put the actual DNA for us in the DevDNAResolveMap
 				if IsDevMode {
-					dnaHashStr := os.Getenv("HCDEV_DNA_FOR_" + zome.BridgeTo)
+					var dnaHashStr string
+					if DevDNAResolveMap != nil {
+						dnaHashStr, _ = DevDNAResolveMap[zome.BridgeTo]
+					}
 
 					dna.Zomes[i].BridgeTo, err = NewHash(dnaHashStr)
 					if err != nil {

--- a/service_test.go
+++ b/service_test.go
@@ -294,7 +294,9 @@ func TestCloneResolveDNA(t *testing.T) {
 		So(h.nucleus.dna.Zomes[0].BridgeTo.String(), ShouldEqual, "")
 
 		root = filepath.Join(s.Path, "test2")
-		os.Setenv("HCDEV_DNA_FOR_bridgeToApp", DNAHash.String())
+		DevDNAResolveMap = make(map[string]string)
+		DevDNAResolveMap["bridgeToApp"] = DNAHash.String()
+
 		h, err = s.Clone(devAppPath, root, agent, CloneWithNewUUID, SkipInitializeDB)
 		So(err, ShouldBeNil)
 		So(h.nucleus.dna.Zomes[0].BridgeTo.String(), ShouldEqual, DNAHash.String())

--- a/test.go
+++ b/test.go
@@ -44,7 +44,7 @@ func SetupTestService() (d string, s *Service) {
 func SetupTestChain(n string) (d string, s *Service, h *Holochain) {
 	d, s = setupTestService()
 	path := filepath.Join(s.Path, n)
-	h, err := s.GenDev(path, "toml", InitializeDB)
+	h, err := s.MakeTestingApp(path, "toml", InitializeDB)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This allows devs to use the name of the app they are bridging to in the BridgeTo Zome field instead of having to constantly update the DNA hash value.

While fixing this I also renamed GenDev() to MakeTestingApp(), which is a much more sane name.