### PR TITLE
NAT traversal with go-libp2p-nat (resolves #321)

### DIFF
--- a/bs.go
+++ b/bs.go
@@ -35,7 +35,7 @@ func (h *Holochain) BSpost() (err error) {
 		return errors.New("Node hasn't been initialized yet.")
 	}
 	nodeID := h.nodeIDStr
-	req := BSReq{Version: 1, NodeID: nodeID, NodeAddr: h.node.NetAddr.String()}
+	req := BSReq{Version: 1, NodeID: nodeID, NodeAddr: h.node.ExternalAddr().String()}
 	host := h.Config.BootstrapServer
 	id := h.DNAHash()
 	url := fmt.Sprintf("http://%s/%s/%s", host, id.String(), nodeID)

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -175,6 +175,11 @@ func GetHolochain(name string, service *holo.Service, cmd string) (h *holo.Holoc
 		return
 	}
 
+  val := os.Getenv("HOLOCHAINCONFIG_ENABLENATUPNP")
+  if val != "" {
+    h.Config.EnableNATUPnP = val == "true"
+  }
+
 	if err = h.Prepare(); err != nil {
 		return
 	}

--- a/cmd/hcadmin/hcadmin_test.go
+++ b/cmd/hcadmin/hcadmin_test.go
@@ -151,7 +151,7 @@ func runAppWithStdoutCapture(app *cli.App, args []string) (out string, err error
 	os.Stdout = w
 
 	go func() { err = app.Run(os.Args) }()
-	time.Sleep(time.Second / 2)
+	time.Sleep(time.Second * 5)
 
 	outC := make(chan string)
 	// copy the output in a separate goroutine so printing can't block indefinitely

--- a/cmd/hcd/hcd.go
+++ b/cmd/hcd/hcd.go
@@ -21,6 +21,7 @@ const (
 
 var debug bool
 var verbose bool
+var nonatupnp bool
 
 func setupApp() (app *cli.App) {
 	app = cli.NewApp()
@@ -49,6 +50,11 @@ func setupApp() (app *cli.App) {
 			Usage:       "verbose output",
 			Destination: &verbose,
 		},
+		cli.BoolFlag{
+			Name:        "no-nat-upnp",
+			Usage:       "whether to stop hcd from creating a port mapping through NAT via UPnP",
+			Destination: &nonatupnp,
+		},
 	}
 
 	app.Before = func(c *cli.Context) error {
@@ -66,6 +72,12 @@ func setupApp() (app *cli.App) {
 		service, err = cmd.GetService(root)
 		if err != nil {
 			return err
+		}
+		if nonatupnp == false {
+			err = os.Setenv("HOLOCHAINCONFIG_ENABLENATUPNP", "true")
+			if err != nil {
+				return err
+			}
 		}
 		return nil
 	}

--- a/cmd/hcd/hcd_test.go
+++ b/cmd/hcd/hcd_test.go
@@ -54,7 +54,7 @@ func TestWeb(t *testing.T) {
 		os.Stdout = w
 
 		go app.Run(os.Args)
-		time.Sleep(time.Second * 2)
+		time.Sleep(time.Second * 10)
 
 		outC := make(chan string)
 		// copy the output in a separate goroutine so printing can't block indefinitely

--- a/cmd/hcd/hcd_test.go
+++ b/cmd/hcd/hcd_test.go
@@ -47,7 +47,7 @@ func TestWeb(t *testing.T) {
 	app := setupApp()
 
 	Convey("it should run a webserver", t, func() {
-		os.Args = []string{"hcd", "-path", s.Path, "-verbose", "testApp"}
+		os.Args = []string{"hcd", "-path", s.Path, "-verbose", "-no-nat-upnp",  "testApp"}
 
 		old := os.Stdout // keep backup of the real stdout
 		r, w, _ := os.Pipe()

--- a/cmd/hcd/hcd_test.go
+++ b/cmd/hcd/hcd_test.go
@@ -54,7 +54,7 @@ func TestWeb(t *testing.T) {
 		os.Stdout = w
 
 		go app.Run(os.Args)
-		time.Sleep(time.Second)
+		time.Sleep(time.Second * 2)
 
 		outC := make(chan string)
 		// copy the output in a separate goroutine so printing can't block indefinitely

--- a/cmd/hcdev/hcdev.go
+++ b/cmd/hcdev/hcdev.go
@@ -504,7 +504,7 @@ func setupApp() (app *cli.App) {
 							"-execpath="+filepath.Join(rootExecDir, roleName),
 							"-port="+strconv.Itoa(freePort),
 							"-mdns=true",
-							"-nat-upnp=true",
+							"-no-nat-upnp=true",
 							"-logPrefix="+logPrefix,
 							"-bootstrapServer=_",
 							fmt.Sprintf("-keepalive=%v", keepalive),

--- a/cmd/hcdev/hcdev.go
+++ b/cmd/hcdev/hcdev.go
@@ -43,6 +43,7 @@ var scenarioConfig *holo.TestConfig
 // flags for holochain config generation
 var port, logPrefix, bootstrapServer string
 var mdns bool
+var nonatupnp bool
 
 // meta flags for program flow control
 var syncPausePath string
@@ -117,6 +118,11 @@ func setupApp() (app *cli.App) {
 			Name:        "mdns",
 			Usage:       "whether to use mdns for local peer discovery",
 			Destination: &mdns,
+		},
+		cli.BoolFlag{
+			Name:        "no-nat-upnp",
+			Usage:       "whether to stop hcdev from creating a port mapping through NAT via UPnP",
+			Destination: &nonatupnp,
 		},
 		cli.StringFlag{
 			Name:        "logPrefix",
@@ -498,6 +504,7 @@ func setupApp() (app *cli.App) {
 							"-execpath="+filepath.Join(rootExecDir, roleName),
 							"-port="+strconv.Itoa(freePort),
 							"-mdns=true",
+							"-nat-upnp=true",
 							"-logPrefix="+logPrefix,
 							"-bootstrapServer=_",
 							fmt.Sprintf("-keepalive=%v", keepalive),
@@ -660,6 +667,12 @@ func setupApp() (app *cli.App) {
 		}
 		if mdns != false {
 			err = os.Setenv("HOLOCHAINCONFIG_ENABLEMDNS", "true")
+			if err != nil {
+				return err
+			}
+		}
+		if nonatupnp == false {
+			err = os.Setenv("HOLOCHAINCONFIG_ENABLENATUPNP", "true")
 			if err != nil {
 				return err
 			}

--- a/cmd/hcdev/hcdev_test.go
+++ b/cmd/hcdev/hcdev_test.go
@@ -225,7 +225,7 @@ func runAppWithStdoutCapture(app *cli.App, args []string) (out string, err error
 	os.Stdout = w
 
 	go func() { err = app.Run(os.Args) }()
-	time.Sleep(time.Second * 2)
+	time.Sleep(time.Second * 10)
 
 	outC := make(chan string)
 	// copy the output in a separate goroutine so printing can't block indefinitely

--- a/cmd/hcdev/hcdev_test.go
+++ b/cmd/hcdev/hcdev_test.go
@@ -225,7 +225,7 @@ func runAppWithStdoutCapture(app *cli.App, args []string) (out string, err error
 	os.Stdout = w
 
 	go func() { err = app.Run(os.Args) }()
-	time.Sleep(time.Second / 2)
+	time.Sleep(time.Second * 2)
 
 	outC := make(chan string)
 	// copy the output in a separate goroutine so printing can't block indefinitely

--- a/cmd/hcdev/hcdev_test.go
+++ b/cmd/hcdev/hcdev_test.go
@@ -203,7 +203,7 @@ func TestWeb(t *testing.T) {
 	defer os.RemoveAll(tmpTestDir)
 
 	Convey("'web' should run a webserver", t, func() {
-		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "web"}, 20)
+		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "web"}, 30)
 		So(err, ShouldBeNil)
 		So(out, ShouldContainSubstring, "on port:4141")
 		So(out, ShouldContainSubstring, "Serving holochain with DNA hash:")
@@ -225,7 +225,6 @@ func runAppWithStdoutCapture(app *cli.App, args []string, secondsToWait int) (ou
 	os.Stdout = w
 
 	go func() { err = app.Run(os.Args) }()
-	time.Sleep(time.Second * secondsToWait)
 
 	outC := make(chan string)
 	// copy the output in a separate goroutine so printing can't block indefinitely
@@ -234,6 +233,8 @@ func runAppWithStdoutCapture(app *cli.App, args []string, secondsToWait int) (ou
 		io.Copy(&buf, r)
 		outC <- buf.String()
 	}()
+
+  time.Sleep(time.Second * secondsToWait)
 
 	// back to normal state
 	w.Close()

--- a/cmd/hcdev/hcdev_test.go
+++ b/cmd/hcdev/hcdev_test.go
@@ -181,7 +181,7 @@ func TestPackage(t *testing.T) {
 	tmpTestDir, app := setupTestingApp("foo")
 	defer os.RemoveAll(tmpTestDir)
 	Convey("'package' should print a scaffold file to stdout", t, func() {
-		scaffold, err := runAppWithStdoutCapture(app, []string{"hcdev", "package"})
+		scaffold, err := runAppWithStdoutCapture(app, []string{"hcdev", "package"}, 2)
 		So(err, ShouldBeNil)
 		So(scaffold, ShouldContainSubstring, fmt.Sprintf(`"ScaffoldVersion": "%s"`, holo.ScaffoldVersion))
 	})
@@ -189,7 +189,7 @@ func TestPackage(t *testing.T) {
 	d := holo.SetupTestDir()
 	defer os.RemoveAll(d)
 	Convey("'package' should output a scaffold file to file", t, func() {
-		runAppWithStdoutCapture(app, []string{"hcdev", "package", filepath.Join(d, "scaff.json")})
+		runAppWithStdoutCapture(app, []string{"hcdev", "package", filepath.Join(d, "scaff.json")}, 2)
 		scaffold, err := holo.ReadFile(d, "scaff.json")
 		So(err, ShouldBeNil)
 		So(string(scaffold), ShouldContainSubstring, fmt.Sprintf(`"ScaffoldVersion": "%s"`, holo.ScaffoldVersion))
@@ -203,7 +203,7 @@ func TestWeb(t *testing.T) {
 	defer os.RemoveAll(tmpTestDir)
 
 	Convey("'web' should run a webserver", t, func() {
-		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "web"})
+		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "web"}, 20)
 		So(err, ShouldBeNil)
 		So(out, ShouldContainSubstring, "on port:4141")
 		So(out, ShouldContainSubstring, "Serving holochain with DNA hash:")
@@ -211,13 +211,13 @@ func TestWeb(t *testing.T) {
 	app = setupApp()
 
 	Convey("'web' not in an app directory should produce error", t, func() {
-		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-path", tmpTestDir, "web"})
+		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-path", tmpTestDir, "web"}, 1)
 		So(err, ShouldBeError)
 		So(out, ShouldContainSubstring, "doesn't look like a holochain app")
 	})
 }
 
-func runAppWithStdoutCapture(app *cli.App, args []string) (out string, err error) {
+func runAppWithStdoutCapture(app *cli.App, args []string, secondsToWait int) (out string, err error) {
 	os.Args = args
 
 	old := os.Stdout // keep backup of the real stdout
@@ -225,7 +225,7 @@ func runAppWithStdoutCapture(app *cli.App, args []string) (out string, err error
 	os.Stdout = w
 
 	go func() { err = app.Run(os.Args) }()
-	time.Sleep(time.Second * 10)
+	time.Sleep(time.Second * secondsToWait)
 
 	outC := make(chan string)
 	// copy the output in a separate goroutine so printing can't block indefinitely

--- a/cmd/hcdev/hcdev_test.go
+++ b/cmd/hcdev/hcdev_test.go
@@ -203,7 +203,7 @@ func TestWeb(t *testing.T) {
 	defer os.RemoveAll(tmpTestDir)
 
 	Convey("'web' should run a webserver", t, func() {
-		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "web"})
+		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "web"})
 		So(err, ShouldBeNil)
 		So(out, ShouldContainSubstring, "on port:4141")
 		So(out, ShouldContainSubstring, "Serving holochain with DNA hash:")

--- a/cmd/hcdev/hcdev_test.go
+++ b/cmd/hcdev/hcdev_test.go
@@ -181,7 +181,7 @@ func TestPackage(t *testing.T) {
 	tmpTestDir, app := setupTestingApp("foo")
 	defer os.RemoveAll(tmpTestDir)
 	Convey("'package' should print a scaffold file to stdout", t, func() {
-		scaffold, err := runAppWithStdoutCapture(app, []string{"hcdev", "package"}, 2)
+		scaffold, err := runAppWithStdoutCapture(app, []string{"hcdev", "package"}, 2 * time.Second)
 		So(err, ShouldBeNil)
 		So(scaffold, ShouldContainSubstring, fmt.Sprintf(`"ScaffoldVersion": "%s"`, holo.ScaffoldVersion))
 	})
@@ -189,7 +189,7 @@ func TestPackage(t *testing.T) {
 	d := holo.SetupTestDir()
 	defer os.RemoveAll(d)
 	Convey("'package' should output a scaffold file to file", t, func() {
-		runAppWithStdoutCapture(app, []string{"hcdev", "package", filepath.Join(d, "scaff.json")}, 2)
+		runAppWithStdoutCapture(app, []string{"hcdev", "package", filepath.Join(d, "scaff.json")}, 2 * time.Second)
 		scaffold, err := holo.ReadFile(d, "scaff.json")
 		So(err, ShouldBeNil)
 		So(string(scaffold), ShouldContainSubstring, fmt.Sprintf(`"ScaffoldVersion": "%s"`, holo.ScaffoldVersion))
@@ -203,7 +203,7 @@ func TestWeb(t *testing.T) {
 	defer os.RemoveAll(tmpTestDir)
 
 	Convey("'web' should run a webserver", t, func() {
-		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "web"}, 30)
+		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "web"}, 30 * time.Second)
 		So(err, ShouldBeNil)
 		So(out, ShouldContainSubstring, "on port:4141")
 		So(out, ShouldContainSubstring, "Serving holochain with DNA hash:")
@@ -211,13 +211,13 @@ func TestWeb(t *testing.T) {
 	app = setupApp()
 
 	Convey("'web' not in an app directory should produce error", t, func() {
-		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-path", tmpTestDir, "web"}, 1)
+		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-path", tmpTestDir, "web"}, 1 * time.Second)
 		So(err, ShouldBeError)
 		So(out, ShouldContainSubstring, "doesn't look like a holochain app")
 	})
 }
 
-func runAppWithStdoutCapture(app *cli.App, args []string, secondsToWait int) (out string, err error) {
+func runAppWithStdoutCapture(app *cli.App, args []string, wait time.Duration) (out string, err error) {
 	os.Args = args
 
 	old := os.Stdout // keep backup of the real stdout
@@ -234,7 +234,7 @@ func runAppWithStdoutCapture(app *cli.App, args []string, secondsToWait int) (ou
 		outC <- buf.String()
 	}()
 
-  time.Sleep(time.Second * secondsToWait)
+  time.Sleep(wait)
 
 	// back to normal state
 	w.Close()

--- a/dht_test.go
+++ b/dht_test.go
@@ -284,7 +284,7 @@ func TestSend(t *testing.T) {
 	defer CleanupTestDir(d)
 
 	agent := h.Agent().(*LibP2PAgent)
-	node, err := NewNode("/ip4/127.0.0.1/tcp/1234", h.dnaHash.String(), agent)
+	node, err := NewNode("/ip4/127.0.0.1/tcp/1234", h.dnaHash.String(), agent, false)
 	if err != nil {
 		panic(err)
 	}

--- a/holochain.go
+++ b/holochain.go
@@ -54,6 +54,7 @@ type Config struct {
 	EnableMDNS      bool
 	PeerModeAuthor  bool
 	PeerModeDHTNode bool
+	EnableNATUPnP   bool
 	BootstrapServer string
 	Loggers         Loggers
 }
@@ -256,7 +257,7 @@ func (h *Holochain) PrepareHashType() (err error) {
 // createNode creates a network node based on the current agent and port data
 func (h *Holochain) createNode() (err error) {
 	listenaddr := fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", h.Config.Port)
-	h.node, err = NewNode(listenaddr, h.dnaHash.String(), h.Agent().(*LibP2PAgent))
+	h.node, err = NewNode(listenaddr, h.dnaHash.String(), h.Agent().(*LibP2PAgent), h.Config.EnableNATUPnP)
 	return
 }
 

--- a/holochain.go
+++ b/holochain.go
@@ -253,8 +253,7 @@ func (h *Holochain) PrepareHashType() (err error) {
 
 // createNode creates a network node based on the current agent and port data
 func (h *Holochain) createNode() (err error) {
-	listenaddr := fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", h.Config.Port)
-	h.node, err = NewNode(listenaddr, h.dnaHash.String(), h.Agent().(*LibP2PAgent))
+	h.node, err = NewNode(h.Config.Port, h.dnaHash.String(), h.Agent().(*LibP2PAgent))
 	return
 }
 

--- a/holochain.go
+++ b/holochain.go
@@ -253,7 +253,8 @@ func (h *Holochain) PrepareHashType() (err error) {
 
 // createNode creates a network node based on the current agent and port data
 func (h *Holochain) createNode() (err error) {
-	h.node, err = NewNode(h.Config.Port, h.dnaHash.String(), h.Agent().(*LibP2PAgent))
+	listenaddr := fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", h.Config.Port)
+	h.node, err = NewNode(listenaddr, h.dnaHash.String(), h.Agent().(*LibP2PAgent))
 	return
 }
 

--- a/node.go
+++ b/node.go
@@ -206,7 +206,7 @@ func (n *Node) discoverAndHandleNat(listenPort int) {
 }
 
 // NewNode creates a new ipfs basichost node with given identity
-func NewNode(listenAddr string, protoMux string, agent *LibP2PAgent) (node *Node, err error) {
+func NewNode(listenAddr string, protoMux string, agent *LibP2PAgent, enableNATUPnP bool) (node *Node, err error) {
 	Debugf("Creating new node with protoMux: %s\n", protoMux)
 	nodeID, _, err := agent.NodeID()
 	if err != nil {
@@ -225,8 +225,12 @@ func NewNode(listenAddr string, protoMux string, agent *LibP2PAgent) (node *Node
 		return
 	}
 
+	if enableNATUPnP {
+		n.discoverAndHandleNat(listenPort)
+	}
+
 	ps := pstore.NewPeerstore()
-	n.discoverAndHandleNat(listenPort)
+
 	n.HashAddr = nodeID
 	priv := agent.PrivKey()
 	ps.AddPrivKey(nodeID, priv)

--- a/node.go
+++ b/node.go
@@ -193,13 +193,13 @@ func (n *Node) discoverAndHandleNat(listenPort int) {
 			Debugf("NAT: successfully created port mapping! External address is: %s", external_addr.String())
 		} else {
 			Debugf("NAT: could not create port mappping. Keep trying...")
-			fmt.Errorf("NAT:-------------------------------------------------------")
-			fmt.Errorf("NAT:---------------------Warning---------------------------")
-			fmt.Errorf("NAT:-------------------------------------------------------")
-			fmt.Errorf("NAT: You seem to be behind a NAT that does not speak UPnP.")
-			fmt.Errorf("NAT: You will have to setup a port forwarding manually.")
-			fmt.Errorf("NAT: This instance is configured to listen on port: %d", listenPort)
-			fmt.Errorf("NAT:-------------------------------------------------------")
+			Infof("NAT:-------------------------------------------------------")
+			Infof("NAT:---------------------Warning---------------------------")
+			Infof("NAT:-------------------------------------------------------")
+			Infof("NAT: You seem to be behind a NAT that does not speak UPnP.")
+			Infof("NAT: You will have to setup a port forwarding manually.")
+			Infof("NAT: This instance is configured to listen on port: %d", listenPort)
+			Infof("NAT:-------------------------------------------------------")
 		}
 
 	}
@@ -216,7 +216,7 @@ func NewNode(listenAddr string, protoMux string, agent *LibP2PAgent, enableNATUP
 	var n Node
 	listenPort, err := strconv.Atoi(strings.Split(listenAddr, "/")[4])
 	if err != nil {
-		fmt.Errorf("Can't parse port from Multiaddress string: %s", listenAddr)
+		Infof("Can't parse port from Multiaddress string: %s", listenAddr)
 		return
 	}
 

--- a/node.go
+++ b/node.go
@@ -12,9 +12,6 @@ import (
 	"encoding/gob"
 	"errors"
 	"fmt"
-	// dsf "github.com/NebulousLabs/go-upnp"
-	eth_nat "github.com/ethereum/go-ethereum/p2p/nat"
-	// stun "github.com/pixelbender/go-stun/stun"
 	nat "github.com/libp2p/go-libp2p-nat"
 	net "github.com/libp2p/go-libp2p-net"
 	peer "github.com/libp2p/go-libp2p-peer"
@@ -28,7 +25,7 @@ import (
 	mh "github.com/multiformats/go-multihash"
 	"gopkg.in/mgo.v2/bson"
 	"io"
-	// go_net "net"
+	go_net "net"
 	"time"
 )
 
@@ -141,6 +138,71 @@ func (n *Node) EnableMDNSDiscovery(notifee discovery.Notifee, interval time.Dura
 	return
 }
 
+func (n *Node) ExternalAddr() ma.Multiaddr {
+	if n.nat == nil {
+		return n.NetAddr
+	} else {
+		mappings := n.nat.Mappings()
+		for i := 0; i < len(mappings); i++ {
+			external_addr, err := mappings[i].ExternalAddr()
+			if err == nil {
+				return external_addr
+			}
+		}
+		return n.NetAddr
+	}
+}
+
+func (n *Node) discoverAndHandleNat(listenPort int) {
+	Debugf("Looking for a NAT...")
+	n.nat = nat.DiscoverNAT()
+	if n.nat == nil {
+		Debugf("No NAT found.")
+	} else {
+		Debugf("Discovered NAT! Trying to aquire public port mapping via UPnP...")
+		ifaces, _ := go_net.Interfaces()
+		// handle err
+		for _, i := range ifaces {
+			addrs, _ := i.Addrs()
+			// handle err
+			for _, addr := range addrs {
+				var ip go_net.IP
+				switch v := addr.(type) {
+				case *go_net.IPNet:
+					ip = v.IP
+				case *go_net.IPAddr:
+					ip = v.IP
+				}
+				if ip.Equal(go_net.IPv4(127, 0, 0, 1)) {
+					continue
+				}
+				addr_string := fmt.Sprintf("/ip4/%s/tcp/%d", ip, listenPort)
+				localaddr, err := ma.NewMultiaddr(addr_string)
+				if err == nil {
+					Debugf("NAT: trying to establish NAT mapping for %s...", addr_string)
+					n.nat.NewMapping(localaddr)
+				}
+			}
+		}
+
+		external_addr := n.ExternalAddr()
+
+		if external_addr != n.NetAddr {
+			Debugf("NAT: successfully created port mapping! External address is: %s", external_addr.String())
+		} else {
+			Debugf("NAT: could not create port mappping. Keep trying...")
+			fmt.Errorf("NAT:-------------------------------------------------------")
+			fmt.Errorf("NAT:---------------------Warning---------------------------")
+			fmt.Errorf("NAT:-------------------------------------------------------")
+			fmt.Errorf("NAT: You seem to be behind a NAT that does not speak UPnP.")
+			fmt.Errorf("NAT: You will have to setup a port forwarding manually.")
+			fmt.Errorf("NAT: This instance is configured to listen on port: %d", listenPort)
+			fmt.Errorf("NAT:-------------------------------------------------------")
+		}
+
+	}
+}
+
 // NewNode creates a new ipfs basichost node with given identity
 func NewNode(listenPort int, protoMux string, agent *LibP2PAgent) (node *Node, err error) {
 	Debugf("Creating new node with protoMux: %s\n", protoMux)
@@ -157,109 +219,7 @@ func NewNode(listenPort int, protoMux string, agent *LibP2PAgent) (node *Node, e
 	}
 
 	ps := pstore.NewPeerstore()
-	/*
-		// connect to router
-		Debugf("upnp: looking for NAT...")
-		d, err := upnp.Discover()
-		if err != nil {
-			Debugf("upnp: couldn't find NAT. Error: %s", err)
-		}
-
-		// discover external IP
-		ip, err := d.ExternalIP()
-		if err != nil {
-			Debugf("upnp: couldn't detect external IP. Error: %s", err)
-		}
-		Debugf("upnp: Your external IP is:", ip)
-
-		// forward a port
-		err = d.Forward(9001, "upnp test")
-		if err != nil {
-			Debugf("upnp: couldn't forward port. Error: %s", err)
-		}
-
-		// un-forward a port
-		err = d.Clear(9001)
-		if err != nil {
-			Debugf("upnp: couldn't clear port. Error: %s", err)
-		}
-
-		// record router's location
-		loc := d.Location()
-
-		// connect to router directly
-		d, err = upnp.Load(loc)
-		if err != nil {
-			Debugf("upnp: couldn't connect to router directly. Error: %s", err)
-		}*/
-
-	nat := eth_nat.Any()
-	ip, err := nat.ExternalIP()
-	if err != nil {
-		Debugf("eth_nat: couldn't connect external IP. Error: %s", err)
-	} else {
-		Debugf("eth_nat: external IP is: %s", ip)
-	}
-
-	err = nat.AddMapping("tcp", 9999, 9999, "holochain", time.Minute*5)
-	if err != nil {
-		Debugf("eth_nat: couldn't create mapping. Error: %s", err)
-	}
-	/*
-		n.nat = nat.DiscoverNAT()
-		if n.nat != nil {
-			Debugf("Discovered NAT!")
-			ifaces, _ := go_net.Interfaces()
-			// handle err
-			for _, i := range ifaces {
-				addrs, _ := i.Addrs()
-				// handle err
-				for _, addr := range addrs {
-					var ip go_net.IP
-					switch v := addr.(type) {
-					case *go_net.IPNet:
-						ip = v.IP
-					case *go_net.IPAddr:
-						ip = v.IP
-					}
-					if ip.Equal(go_net.IPv4(127, 0, 0, 1)) {
-						continue
-					}
-					addr_string := fmt.Sprintf("/ip4/%s/tcp/%d", ip, listenPort)
-					localaddr, err := ma.NewMultiaddr(addr_string)
-					if err == nil {
-						Debugf("NAT: trying to establish NAT mapping for %s...", addr_string)
-						n.nat.NewMapping(localaddr)
-					}
-				}
-			}
-
-			Debugf("NAT: Trying to punch hole through NAT via STUN")
-			conn, addr, err := stun.Discover("stun:stun.l.google.com:19302")
-			if err == nil {
-				defer conn.Close()
-				Debugf("NAT: STUN: Local address: %v, Server reflexive address: %v", conn.LocalAddr(), addr)
-			}
-
-			go func() {
-				for true {
-					mappings := n.nat.Mappings()
-					Debugf("NAT: have %d mappings", len(mappings))
-					for i := 0; i < len(mappings); i++ {
-						external_addr, err := mappings[i].ExternalAddr()
-						Debugf("NAT: Mapping %d:", i)
-						if err != nil {
-							Debugf("NAT: Could not get through NAT. Mapping error: %s", err)
-						} else {
-							Debugf("NAT: Success! External address is %s",
-								external_addr.String())
-						}
-					}
-					time.Sleep(time.Second)
-				}
-			}()
-		}*/
-
+	n.discoverAndHandleNat(listenPort)
 	n.HashAddr = nodeID
 	priv := agent.PrivKey()
 	ps.AddPrivKey(nodeID, priv)

--- a/node.go
+++ b/node.go
@@ -26,6 +26,8 @@ import (
 	"gopkg.in/mgo.v2/bson"
 	"io"
 	go_net "net"
+	"strconv"
+	"strings"
 	"time"
 )
 
@@ -204,7 +206,7 @@ func (n *Node) discoverAndHandleNat(listenPort int) {
 }
 
 // NewNode creates a new ipfs basichost node with given identity
-func NewNode(listenPort int, protoMux string, agent *LibP2PAgent) (node *Node, err error) {
+func NewNode(listenAddr string, protoMux string, agent *LibP2PAgent) (node *Node, err error) {
 	Debugf("Creating new node with protoMux: %s\n", protoMux)
 	nodeID, _, err := agent.NodeID()
 	if err != nil {
@@ -212,7 +214,12 @@ func NewNode(listenPort int, protoMux string, agent *LibP2PAgent) (node *Node, e
 	}
 
 	var n Node
-	listenAddr := fmt.Sprintf("/ip4/0.0.0.0/tcp/%d", listenPort)
+	listenPort, err := strconv.Atoi(strings.Split(listenAddr, "/")[4])
+	if err != nil {
+		fmt.Errorf("Can't parse port from Multiaddress string: %s", listenAddr)
+		return
+	}
+
 	n.NetAddr, err = ma.NewMultiaddr(listenAddr)
 	if err != nil {
 		return

--- a/node_test.go
+++ b/node_test.go
@@ -354,5 +354,5 @@ func makeNode(port int, id string) (*Node, error) {
 	listenaddr := fmt.Sprintf("/ip4/127.0.0.1/tcp/%d", port)
 	_, key := makePeer(id)
 	agent := LibP2PAgent{identity: AgentIdentity(id), priv: key, pub: key.GetPublic()}
-	return NewNode(listenaddr, "fakednahash", &agent)
+	return NewNode(listenaddr, "fakednahash", &agent, false)
 }

--- a/service.go
+++ b/service.go
@@ -77,6 +77,7 @@ type ServiceConfig struct {
 	DefaultPeerModeDHTNode bool
 	DefaultBootstrapServer string
 	DefaultEnableMDNS      bool
+	DefaultEnableNATUPnP   bool
 }
 
 // A Service is a Holochain service data structure
@@ -159,6 +160,7 @@ func Init(root string, agent AgentIdentity) (service *Service, err error) {
 			DefaultPeerModeAuthor:  true,
 			DefaultBootstrapServer: DefaultBootstrapServer,
 			DefaultEnableMDNS:      false,
+			DefaultEnableNATUPnP:   false,
 		},
 		Path: root,
 	}
@@ -556,6 +558,7 @@ func _makeConfig(s *Service) (config Config, err error) {
 		PeerModeDHTNode: s.Settings.DefaultPeerModeDHTNode,
 		PeerModeAuthor:  s.Settings.DefaultPeerModeAuthor,
 		BootstrapServer: s.Settings.DefaultBootstrapServer,
+		EnableNATUPnP:   s.Settings.DefaultEnableNATUPnP,
 		Loggers: Loggers{
 			App:        Logger{Name: "App", Format: "%{color:cyan}%{message}", Enabled: true},
 			DHT:        Logger{Name: "DHT", Format: "%{color:yellow}%{time} DHT: %{message}"},
@@ -591,6 +594,12 @@ func _makeConfig(s *Service) (config Config, err error) {
 	if val != "" {
 		Debugf("makeConfig: using environment variable to set enableMDNS to: %s", val)
 		config.EnableMDNS = val == "true"
+	}
+
+	val = os.Getenv("HOLOCHAINCONFIG_ENABLENATUPNP")
+	if val != "" {
+		Debugf("makeConfig: using environment variable to set enableNATUPnP to: %s", val)
+		config.EnableNATUPnP = val == "true"
 	}
 	return
 }

--- a/service_test.go
+++ b/service_test.go
@@ -27,7 +27,7 @@ func TestInit(t *testing.T) {
 
 		Convey("it should return a service with default values", func() {
 			So(s.DefaultAgent.Identity(), ShouldEqual, AgentIdentity(agent))
-			So(fmt.Sprintf("%v", s.Settings), ShouldEqual, "{true true bootstrap.holochain.net:10000 false}")
+			So(fmt.Sprintf("%v", s.Settings), ShouldEqual, "{true true bootstrap.holochain.net:10000 false false}")
 		})
 
 		p := filepath.Join(d, DefaultDirectoryName)


### PR DESCRIPTION
Uses go-libp2p-nat to discover a NAT and if there is one tries to create mappings (for each local IPv4 address). Since not every router allows that (or speaks UPnP at all) we need to do more. So I'm also playing with go-stun, which calls a STUN server (here one from Google) to find out our external IP and port.

