### PR TITLE
additions to sys validation, closes #161

### DIFF
--- a/action.go
+++ b/action.go
@@ -60,7 +60,7 @@ type Action interface {
 type CommittingAction interface {
 	Name() string
 	Do(h *Holochain) (response interface{}, err error)
-	SysValidation(h *Holochain, d *EntryDef, sources []peer.ID) (err error)
+	SysValidation(h *Holochain, def *EntryDef, pkg *Package, sources []peer.ID) (err error)
 	Receive(dht *DHT, msg *Message) (response interface{}, err error)
 	CheckValidationRequest(def *EntryDef) (err error)
 	Args() []Arg
@@ -72,7 +72,7 @@ type CommittingAction interface {
 type ValidatingAction interface {
 	Name() string
 	Do(h *Holochain) (response interface{}, err error)
-	SysValidation(h *Holochain, d *EntryDef, sources []peer.ID) (err error)
+	SysValidation(h *Holochain, def *EntryDef, pkg *Package, sources []peer.ID) (err error)
 	Receive(dht *DHT, msg *Message) (response interface{}, err error)
 	CheckValidationRequest(def *EntryDef) (err error)
 	Args() []Arg
@@ -80,6 +80,9 @@ type ValidatingAction interface {
 
 var NonDHTAction error = errors.New("Not a DHT action")
 var NonCallableAction error = errors.New("Not a callable action")
+var ErrNotValidForDNAType error = errors.New("Invalid action for DNA type")
+var ErrNotValidForAgentType error = errors.New("Invalid action for Agent type")
+var ErrNotValidForKeyType error = errors.New("Invalid action for Key type")
 
 func prepareSources(sources []peer.ID) (srcs []string) {
 	srcs = make([]string, 0)
@@ -90,34 +93,26 @@ func prepareSources(sources []peer.ID) (srcs []string) {
 }
 
 // ValidateAction runs the different phases of validating an action
-func (h *Holochain) ValidateAction(a ValidatingAction, entryType string, pkg *Package, sources []peer.ID) (d *EntryDef, err error) {
-	switch entryType {
-	case DNAEntryType:
-		//		panic("attempt to get validation response for DNA")
-	case KeyEntryType:
-		//		validate the public key?
-	case AgentEntryType:
-		//		validate the Agent Entry?
-	default:
+func (h *Holochain) ValidateAction(a ValidatingAction, entryType string, pkg *Package, sources []peer.ID) (def *EntryDef, err error) {
+
+	var z *Zome
+	z, def, err = h.GetEntryDef(entryType)
+	if err != nil {
+		return
+	}
+
+	// run the action's system level validations
+	err = a.SysValidation(h, def, pkg, sources)
+	if err != nil {
+		Debugf("Sys ValidateAction(%T) err:%v\n", a, err)
+		return
+	}
+	if !def.IsSysEntry() {
 
 		// validation actions for application defined entry types
-
-		var z *Zome
-		z, d, err = h.GetEntryDef(entryType)
-		if err != nil {
-			return
-		}
-
 		var vpkg *ValidationPackage
 		vpkg, err = MakeValidationPackage(h, pkg)
 		if err != nil {
-			return
-		}
-
-		// run the action's system level validations
-		err = a.SysValidation(h, d, sources)
-		if err != nil {
-			Debugf("Sys ValidateAction(%T) err:%v\n", a, err)
 			return
 		}
 
@@ -128,7 +123,7 @@ func (h *Holochain) ValidateAction(a ValidatingAction, entryType string, pkg *Pa
 			return
 		}
 
-		err = n.ValidateAction(a, d, vpkg, prepareSources(sources))
+		err = n.ValidateAction(a, def, vpkg, prepareSources(sources))
 		if err != nil {
 			Debugf("Ribosome ValidateAction(%T) err:%v\n", a, err)
 		}
@@ -144,6 +139,12 @@ func (h *Holochain) GetValidationResponse(a ValidatingAction, hash Hash) (resp V
 	if err == ErrHashNotFound {
 		if hash.String() == h.nodeIDStr {
 			resp.Type = KeyEntryType
+			var pk []byte
+			pk, err = ic.MarshalPublicKey(h.agent.PubKey())
+			if err != nil {
+				return
+			}
+			resp.Entry.C = pk
 			err = nil
 		} else {
 			return
@@ -161,11 +162,15 @@ func (h *Holochain) GetValidationResponse(a ValidatingAction, hash Hash) (resp V
 	}
 	switch resp.Type {
 	case DNAEntryType:
-		panic("attempt to get validation response for DNA")
+		err = ErrNotValidForDNAType
+		return
 	case KeyEntryType:
-		//		resp.Entry = TODO public key goes here
+		// if key entry there no extra info to return in the package so do nothing
 	case AgentEntryType:
-		//		resp.Entry = TODO agent block goes here
+		// if agent, the package to return is the entry-type chain
+		// so that sys validation can confirm this agent entry in the chain
+		req := PackagingReq{PkgReqChain: int64(PkgReqChainOptFull), PkgReqEntryTypes: []string{AgentEntryType}}
+		resp.Package, err = MakePackage(h, req)
 	default:
 		// app defined entry types
 		var def *EntryDef
@@ -584,7 +589,6 @@ func (a *ActionQuery) Do(h *Holochain) (response interface{}, err error) {
 
 //------------------------------------------------------------
 // Get
-
 type ActionGet struct {
 	req     GetReq
 	options *GetOptions
@@ -651,7 +655,7 @@ func (a *ActionGet) Do(h *Holochain) (response interface{}, err error) {
 	return
 }
 
-func (a *ActionGet) SysValidation(h *Holochain, d *EntryDef, sources []peer.ID) (err error) {
+func (a *ActionGet) SysValidation(h *Holochain, def *EntryDef, pkg *Package, sources []peer.ID) (err error) {
 	return
 }
 
@@ -722,9 +726,6 @@ func (h *Holochain) doCommit(a CommittingAction, change *StatusChange) (d *Entry
 	//TODO	a.header = header
 	d, err = h.ValidateAction(a, entryType, nil, []peer.ID{h.nodeID})
 	if err != nil {
-		if err == ValidationFailedErr {
-			err = fmt.Errorf("Invalid entry: %v", entry.Content())
-		}
 		return
 	}
 	err = h.chain.addEntry(l, hash, header, entry)
@@ -804,18 +805,63 @@ func (a *ActionCommit) Do(h *Holochain) (response interface{}, err error) {
 	return
 }
 
-// sysValidateEntry does system level validation for an entry
+// sysValidateEntry does system level validation for adding an entry (put or commit)
 // It checks that entry is not nil, and that it conforms to the entry schema in the definition
-// and if it's a Links entry that the contents are correctly structured
-func sysValidateEntry(h *Holochain, d *EntryDef, entry Entry) (err error) {
+// if it's a Links entry that the contents are correctly structured
+// if it's a new agent entry, that identity matches the defined identity structure
+// if it's a key that the structure is actually a public key
+func sysValidateEntry(h *Holochain, def *EntryDef, entry Entry, pkg *Package) (err error) {
+	switch def.Name {
+	case DNAEntryType:
+		err = ErrNotValidForDNAType
+		return
+	case KeyEntryType:
+		pk, ok := entry.Content().([]byte)
+		if !ok || len(pk) != 36 {
+			err = ValidationFailedErr
+			return
+		} else {
+			_, err = ic.UnmarshalPublicKey(pk)
+			if err != nil {
+				err = ValidationFailedErr
+				return err
+			}
+		}
+	case AgentEntryType:
+		ae, ok := entry.Content().(AgentEntry)
+		if !ok {
+			err = ValidationFailedErr
+			return
+		}
+
+		// check that the public key is unmarshalable
+		_, err = ic.UnmarshalPublicKey(ae.PublicKey)
+		if err != nil {
+			err = ValidationFailedErr
+			return err
+		}
+
+		// if there's a revocation, confirm that has a reasonable format
+		if ae.Revocation != nil {
+			revocation := &SelfRevocation{}
+			err := revocation.Unmarshal(ae.Revocation)
+			if err != nil {
+				err = ValidationFailedErr
+				return err
+			}
+		}
+
+		// TODO check anything in the package
+	}
+
 	if entry == nil {
 		err = errors.New("nil entry invalid")
 		return
 	}
 	// see if there is a schema validator for the entry type and validate it if so
-	if d.validator != nil {
+	if def.validator != nil {
 		var input interface{}
-		if d.DataFormat == DataFormatJSON {
+		if def.DataFormat == DataFormatJSON {
 			if err = json.Unmarshal([]byte(entry.Content().(string)), &input); err != nil {
 				return
 			}
@@ -823,10 +869,10 @@ func sysValidateEntry(h *Holochain, d *EntryDef, entry Entry) (err error) {
 			input = entry
 		}
 		Debugf("Validating %v against schema", input)
-		if err = d.validator.Validate(input); err != nil {
+		if err = def.validator.Validate(input); err != nil {
 			return
 		}
-	} else if d.DataFormat == DataFormatLinks {
+	} else if def.DataFormat == DataFormatLinks {
 		// Perform base validation on links entries, i.e. that all items exist and are of the right types
 		// so first unmarshall the json, and then check that the hashes are real.
 		var l struct{ Links []map[string]string }
@@ -869,8 +915,8 @@ func sysValidateEntry(h *Holochain, d *EntryDef, entry Entry) (err error) {
 	return
 }
 
-func (a *ActionCommit) SysValidation(h *Holochain, d *EntryDef, sources []peer.ID) (err error) {
-	err = sysValidateEntry(h, d, a.entry)
+func (a *ActionCommit) SysValidation(h *Holochain, def *EntryDef, pkg *Package, sources []peer.ID) (err error) {
+	err = sysValidateEntry(h, def, a.entry, pkg)
 	return
 }
 
@@ -910,8 +956,8 @@ func (a *ActionPut) Do(h *Holochain) (response interface{}, err error) {
 	return
 }
 
-func (a *ActionPut) SysValidation(h *Holochain, d *EntryDef, sources []peer.ID) (err error) {
-	err = sysValidateEntry(h, d, a.entry)
+func (a *ActionPut) SysValidation(h *Holochain, def *EntryDef, pkg *Package, sources []peer.ID) (err error) {
+	err = sysValidateEntry(h, def, a.entry, pkg)
 	return
 }
 
@@ -1018,21 +1064,34 @@ func (a *ActionMod) Do(h *Holochain) (response interface{}, err error) {
 	return
 }
 
-func (a *ActionMod) SysValidation(h *Holochain, def *EntryDef, sources []peer.ID) (err error) {
+func (a *ActionMod) SysValidation(h *Holochain, def *EntryDef, pkg *Package, sources []peer.ID) (err error) {
+	switch def.Name {
+	case DNAEntryType:
+		err = ErrNotValidForDNAType
+		return
+	case KeyEntryType:
+	case AgentEntryType:
+	}
+
 	if def.DataFormat == DataFormatLinks {
 		err = errors.New("Can't mod Links entry")
 		return
 	}
-	var header *Header
-	header, err = h.chain.GetEntryHeader(a.replaces)
-	if err != nil {
-		return
+
+	// no need to check for virtual entries on the chain because they aren't there
+	// currently the only virtual entry is the node id
+	if !def.IsVirtualEntry() {
+		var header *Header
+		header, err = h.chain.GetEntryHeader(a.replaces)
+		if err != nil {
+			return
+		}
+		if header.Type != a.entryType {
+			err = ErrEntryTypeMismatch
+			return
+		}
 	}
-	if header.Type != a.entryType {
-		err = ErrEntryTypeMismatch
-		return
-	}
-	err = sysValidateEntry(h, def, a.entry)
+	err = sysValidateEntry(h, def, a.entry, pkg)
 	return
 }
 
@@ -1230,11 +1289,27 @@ func (a *ActionDel) Do(h *Holochain) (response interface{}, err error) {
 	return
 }
 
-func (a *ActionDel) SysValidation(h *Holochain, d *EntryDef, sources []peer.ID) (err error) {
-	if d.DataFormat == DataFormatLinks {
+func (a *ActionDel) SysValidation(h *Holochain, def *EntryDef, pkg *Package, sources []peer.ID) (err error) {
+	switch def.Name {
+	case DNAEntryType:
+		err = ErrNotValidForDNAType
+		return
+	case KeyEntryType:
+		err = ErrNotValidForKeyType
+		return
+	case AgentEntryType:
+		err = ErrNotValidForAgentType
+		return
+	}
+
+	if def.DataFormat == DataFormatLinks {
 		err = errors.New("Can't del Links entry")
 		return
 	}
+
+	// we don't have to check to see if the entry type is virtual here because currently
+	// the only virtual entry type is the KeyEntryType, for which Del isn't even valid
+	// and will have gotten caught in the switch statement above so no use wasting CPU cycles.
 	var header *Header
 	header, err = h.chain.GetEntryHeader(a.entry.Hash)
 	if err != nil {
@@ -1313,7 +1388,10 @@ func (a *ActionLink) Do(h *Holochain) (response interface{}, err error) {
 	return
 }
 
-func (a *ActionLink) SysValidation(h *Holochain, d *EntryDef, sources []peer.ID) (err error) {
+func (a *ActionLink) SysValidation(h *Holochain, def *EntryDef, pkg *Package, sources []peer.ID) (err error) {
+	if def.DataFormat != DataFormatLinks {
+		err = errors.New("action only valid for links entry type")
+	}
 	//@TODO what sys level links validation?  That they are all valid hash format for the DNA?
 	return
 }
@@ -1434,7 +1512,7 @@ func (a *ActionGetLink) Do(h *Holochain) (response interface{}, err error) {
 	return
 }
 
-func (a *ActionGetLink) SysValidation(h *Holochain, d *EntryDef, sources []peer.ID) (err error) {
+func (a *ActionGetLink) SysValidation(h *Holochain, d *EntryDef, pkg *Package, sources []peer.ID) (err error) {
 	//@TODO what sys level getlinks validation?  That they are all valid hash format for the DNA?
 	return
 }

--- a/action_test.go
+++ b/action_test.go
@@ -3,6 +3,7 @@ package holochain
 import (
 	// "fmt"
 	"fmt"
+	ic "github.com/libp2p/go-libp2p-crypto"
 	peer "github.com/libp2p/go-libp2p-peer"
 	. "github.com/metacurrency/holochain/hash"
 	. "github.com/smartystreets/goconvey/convey"
@@ -36,14 +37,97 @@ func TestValidateAction(t *testing.T) {
 		_, err = h.ValidateAction(a, a.entryType, nil, []peer.ID{h.nodeID})
 		So(err, ShouldEqual, ValidationFailedErr)
 	})
+
+	// these test the sys type cases
+	Convey("adding or changing dna should fail", t, func() {
+		entry := &GobEntry{C: "fakeDNA"}
+		a := NewCommitAction(DNAEntryType, entry)
+		_, err = h.ValidateAction(a, a.entryType, nil, []peer.ID{h.nodeID})
+		So(err, ShouldEqual, ErrNotValidForDNAType)
+		ap := NewPutAction(DNAEntryType, entry, nil)
+		_, err = h.ValidateAction(ap, ap.entryType, nil, []peer.ID{h.nodeID})
+		So(err, ShouldEqual, ErrNotValidForDNAType)
+		am := NewModAction(DNAEntryType, entry, HashFromPeerID(h.nodeID))
+		_, err = h.ValidateAction(am, am.entryType, nil, []peer.ID{h.nodeID})
+		So(err, ShouldEqual, ErrNotValidForDNAType)
+	})
+
+	Convey("deleting all sys entry types should fail", t, func() {
+		a := NewDelAction(DNAEntryType, DelEntry{})
+		_, err = h.ValidateAction(a, a.entryType, nil, []peer.ID{h.nodeID})
+		So(err, ShouldEqual, ErrNotValidForDNAType)
+		a.entryType = KeyEntryType
+		_, err = h.ValidateAction(a, a.entryType, nil, []peer.ID{h.nodeID})
+		So(err, ShouldEqual, ErrNotValidForKeyType)
+		a.entryType = AgentEntryType
+		_, err = h.ValidateAction(a, a.entryType, nil, []peer.ID{h.nodeID})
+		So(err, ShouldEqual, ErrNotValidForAgentType)
+	})
 }
 
 func TestSysValidateEntry(t *testing.T) {
 	d, _, h := PrepareTestChain("test")
 	defer CleanupTestChain(h, d)
 
+	Convey("key entry should be a public key", t, func() {
+		e := &GobEntry{}
+		err := sysValidateEntry(h, KeyEntryDef, e, nil)
+		So(err, ShouldEqual, ValidationFailedErr)
+		e.C = []byte{1, 2, 3}
+		err = sysValidateEntry(h, KeyEntryDef, e, nil)
+		So(err, ShouldEqual, ValidationFailedErr)
+
+		e.C = []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6}
+		err = sysValidateEntry(h, KeyEntryDef, e, nil)
+		So(err, ShouldEqual, ValidationFailedErr)
+
+		pk, _ := ic.MarshalPublicKey(h.agent.PubKey())
+		e.C = pk
+		err = sysValidateEntry(h, KeyEntryDef, e, nil)
+		So(err, ShouldBeNil)
+	})
+
+	Convey("an agent entry should have the correct structure as defined", t, func() {
+		e := &GobEntry{}
+		err := sysValidateEntry(h, AgentEntryDef, e, nil)
+		So(err, ShouldEqual, ValidationFailedErr)
+
+		// bad agent entry (empty)
+		e.C = AgentEntry{}
+		err = sysValidateEntry(h, AgentEntryDef, e, nil)
+		So(err, ShouldEqual, ValidationFailedErr)
+
+		ae, _ := h.agent.AgentEntry(nil)
+		// bad public key
+		ae.PublicKey = nil
+		e.C = ae
+		err = sysValidateEntry(h, AgentEntryDef, e, nil)
+		So(err, ShouldEqual, ValidationFailedErr)
+
+		ae, _ = h.agent.AgentEntry(nil)
+		// bad public key
+		ae.PublicKey = []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6}
+		e.C = ae
+		err = sysValidateEntry(h, AgentEntryDef, e, nil)
+		So(err, ShouldEqual, ValidationFailedErr)
+
+		ae, _ = h.agent.AgentEntry(nil)
+		// bad revocation
+		ae.Revocation = []byte{1, 2, 3}
+		e.C = ae
+		err = sysValidateEntry(h, AgentEntryDef, e, nil)
+		So(err, ShouldEqual, ValidationFailedErr)
+
+		ae, _ = h.agent.AgentEntry(nil)
+		e.C = ae
+		err = sysValidateEntry(h, AgentEntryDef, e, nil)
+		So(err, ShouldBeNil)
+	})
+
+	_, def, _ := h.GetEntryDef("rating")
+
 	Convey("a nil entry is invalid", t, func() {
-		err := sysValidateEntry(h, nil, nil)
+		err := sysValidateEntry(h, def, nil, nil)
 		So(err.Error(), ShouldEqual, "nil entry invalid")
 	})
 
@@ -51,34 +135,32 @@ func TestSysValidateEntry(t *testing.T) {
 		profile := `{"firstName":"Eric"}` // missing required lastName
 		_, def, _ := h.GetEntryDef("profile")
 
-		err := sysValidateEntry(h, def, &GobEntry{C: profile})
+		err := sysValidateEntry(h, def, &GobEntry{C: profile}, nil)
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldEqual, "validator profile failed: object property 'lastName' is required")
 	})
 
-	_, def, _ := h.GetEntryDef("rating")
-
 	Convey("validate on a links entry should fail if not formatted correctly", t, func() {
-		err := sysValidateEntry(h, def, &GobEntry{C: "badjson"})
+		err := sysValidateEntry(h, def, &GobEntry{C: "badjson"}, nil)
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldEqual, "invalid links entry, invalid json: invalid character 'b' looking for beginning of value")
 
-		err = sysValidateEntry(h, def, &GobEntry{C: `{}`})
+		err = sysValidateEntry(h, def, &GobEntry{C: `{}`}, nil)
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldEqual, "invalid links entry: you must specify at least one link")
 
-		err = sysValidateEntry(h, def, &GobEntry{C: `{"Links":[{}]}`})
+		err = sysValidateEntry(h, def, &GobEntry{C: `{"Links":[{}]}`}, nil)
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldEqual, "invalid links entry: missing Base")
 
-		err = sysValidateEntry(h, def, &GobEntry{C: `{"Links":[{"Base":"x","Link":"x","Tag":"sometag"}]}`})
+		err = sysValidateEntry(h, def, &GobEntry{C: `{"Links":[{"Base":"x","Link":"x","Tag":"sometag"}]}`}, nil)
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldEqual, "invalid links entry: Base multihash too short. must be > 3 bytes")
-		err = sysValidateEntry(h, def, &GobEntry{C: `{"Links":[{"Base":"QmdRXz53TVT9qBYfbXctHyy2GpTNa6YrpAy6ZcDGG8Xhc5","Link":"x","Tag":"sometag"}]}`})
+		err = sysValidateEntry(h, def, &GobEntry{C: `{"Links":[{"Base":"QmdRXz53TVT9qBYfbXctHyy2GpTNa6YrpAy6ZcDGG8Xhc5","Link":"x","Tag":"sometag"}]}`}, nil)
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldEqual, "invalid links entry: Link multihash too short. must be > 3 bytes")
 
-		err = sysValidateEntry(h, def, &GobEntry{C: `{"Links":[{"Base":"QmdRXz53TVT9qBYfbXctHyy2GpTNa6YrpAy6ZcDGG8Xhc5","Link":"QmdRXz53TVT9qBYfbXctHyy2GpTNa6YrpAy6ZcDGG8Xhc5"}]}`})
+		err = sysValidateEntry(h, def, &GobEntry{C: `{"Links":[{"Base":"QmdRXz53TVT9qBYfbXctHyy2GpTNa6YrpAy6ZcDGG8Xhc5","Link":"QmdRXz53TVT9qBYfbXctHyy2GpTNa6YrpAy6ZcDGG8Xhc5"}]}`}, nil)
 		So(err, ShouldNotBeNil)
 		So(err.Error(), ShouldEqual, "invalid links entry: missing Tag")
 	})
@@ -93,20 +175,20 @@ func TestSysValidateMod(t *testing.T) {
 
 	Convey("it should check that entry types match on mod", t, func() {
 		a := NewModAction("oddNumbers", &GobEntry{}, hash)
-		err := a.SysValidation(h, def, []peer.ID{h.nodeID})
+		err := a.SysValidation(h, def, nil, []peer.ID{h.nodeID})
 		So(err, ShouldEqual, ErrEntryTypeMismatch)
 	})
 
 	Convey("it should check that entry isn't linking ", t, func() {
 		a := NewModAction("rating", &GobEntry{}, hash)
 		_, ratingsDef, _ := h.GetEntryDef("rating")
-		err := a.SysValidation(h, ratingsDef, []peer.ID{h.nodeID})
+		err := a.SysValidation(h, ratingsDef, nil, []peer.ID{h.nodeID})
 		So(err.Error(), ShouldEqual, "Can't mod Links entry")
 	})
 
 	Convey("it should check that entry validates", t, func() {
 		a := NewModAction("evenNumbers", nil, hash)
-		err := a.SysValidation(h, def, []peer.ID{h.nodeID})
+		err := a.SysValidation(h, def, nil, []peer.ID{h.nodeID})
 		So(err.Error(), ShouldEqual, "nil entry invalid")
 	})
 }
@@ -120,14 +202,14 @@ func TestSysValidateDel(t *testing.T) {
 
 	Convey("it should check that entry types match on del", t, func() {
 		a := NewDelAction("oddNumbers", DelEntry{Hash: hash})
-		err := a.SysValidation(h, def, []peer.ID{h.nodeID})
+		err := a.SysValidation(h, def, nil, []peer.ID{h.nodeID})
 		So(err, ShouldEqual, ErrEntryTypeMismatch)
 	})
 
 	Convey("it should check that entry isn't linking ", t, func() {
 		a := NewDelAction("rating", DelEntry{Hash: hash})
 		_, ratingsDef, _ := h.GetEntryDef("rating")
-		err := a.SysValidation(h, ratingsDef, []peer.ID{h.nodeID})
+		err := a.SysValidation(h, ratingsDef, nil, []peer.ID{h.nodeID})
 		So(err.Error(), ShouldEqual, "Can't del Links entry")
 	})
 }

--- a/dht.go
+++ b/dht.go
@@ -646,7 +646,7 @@ func (dht *DHT) Change(key Hash, msgType MsgType, body interface{}) (err error) 
 	_, err = dht.send(nil, dht.h.nodeID, msgType, body)
 
 	if err != nil {
-		dht.dlog.Logf("DHT %s failed to self with error: %s", msgType, err)
+		dht.dlog.Logf("DHT send of %v to self failed with error: %s", msgType, err)
 		err = nil
 	}
 	node := dht.h.node
@@ -666,7 +666,7 @@ func (dht *DHT) Change(key Hash, msgType MsgType, body interface{}) (err error) 
 
 			_, err := dht.send(ctx, p, msgType, body)
 			if err != nil {
-				dht.dlog.Logf("DHT %s failed to peer %v with error: %s", msgType, p, err)
+				dht.dlog.Logf("DHT send of %v failed to peer %v with error: %s", msgType, p, err)
 			}
 		}(p)
 	}

--- a/entry.go
+++ b/entry.go
@@ -12,15 +12,18 @@ import (
 	"github.com/lestrrat/go-jsval"
 	. "github.com/metacurrency/holochain/hash"
 	"io"
+	"strings"
 )
 
 const (
+	SysEntryTypePrefix     = "%"
+	VirtualEntryTypePrefix = "%%"
 
 	// System defined entry types
 
-	DNAEntryType   = "%dna"
-	AgentEntryType = "%agent"
-	KeyEntryType   = "%%key" // virtual entry type, not actually on the chain
+	DNAEntryType   = SysEntryTypePrefix + "dna"
+	AgentEntryType = SysEntryTypePrefix + "agent"
+	KeyEntryType   = VirtualEntryTypePrefix + "key" // virtual entry type, not actually on the chain
 
 	// Entry type formats
 
@@ -99,6 +102,16 @@ type GobEntry struct {
 // JSONEntry is a structure for implementing JSON encoding of Entry content
 type JSONEntry struct {
 	C interface{}
+}
+
+// IsSysEntry returns true if the entry type is system defined
+func (def *EntryDef) IsSysEntry() bool {
+	return strings.HasPrefix(def.Name, SysEntryTypePrefix)
+}
+
+// IsVirtualEntry returns true if the entry type is virtual
+func (def *EntryDef) IsVirtualEntry() bool {
+	return strings.HasPrefix(def.Name, VirtualEntryTypePrefix)
 }
 
 // MarshalEntry serializes an entry to a writer

--- a/holochain_test.go
+++ b/holochain_test.go
@@ -469,7 +469,7 @@ func TestCall(t *testing.T) {
 		So(result.(string), ShouldEqual, ph.String())
 
 		_, err = h.Call("zySampleZome", "addEven", "41", ZOME_EXPOSURE)
-		So(err.Error(), ShouldEqual, "Error calling 'commit': Invalid entry: 41")
+		So(err.Error(), ShouldEqual, "Error calling 'commit': Validation Failed")
 	})
 	Convey("it should fail calls to functions not exposed to the given context", t, func() {
 		_, err := h.Call("zySampleZome", "testStrFn1", "arg1 arg2", PUBLIC_EXPOSURE)

--- a/jsribosome.go
+++ b/jsribosome.go
@@ -270,10 +270,6 @@ func (jsr *JSRibosome) validateEntry(fnName string, def *EntryDef, entry Entry, 
 	code := fmt.Sprintf(`%s("%s",%s,%s,%s)`, fnName, def.Name, e, hdr, srcs)
 	Debugf("%s: %s", fnName, code)
 	err = jsr.runValidate(fnName, code)
-	if err != nil && err == ValidationFailedErr {
-		err = fmt.Errorf("Invalid entry: %v", entry.Content())
-	}
-
 	return
 }
 

--- a/node.go
+++ b/node.go
@@ -86,6 +86,26 @@ const (
 	FIND_NODE_REQUEST
 )
 
+func (msgType MsgType) String() string {
+	return []string{"ERROR_RESPONSE",
+		"OK_RESPONSE",
+		"PUT_REQUEST",
+		"DEL_REQUEST",
+		"MOD_REQUEST",
+		"GET_REQUEST",
+		"LINK_REQUEST",
+		"GETLINK_REQUEST",
+		"DELETELINK_REQUEST",
+		"GOSSIP_REQUEST",
+		"VALIDATE_PUT_REQUEST",
+		"VALIDATE_LINK_REQUEST",
+		"VALIDATE_DEL_REQUEST",
+		"VALIDATE_MOD_REQUEST",
+		"APP_MESSAGE",
+		"LISTADD_REQUEST",
+		"FIND_NODE_REQUEST"}[msgType]
+}
+
 var ErrBlockedListed = errors.New("node blockedlisted")
 
 // Message represents data that can be sent to node in the network
@@ -349,44 +369,7 @@ func (m *Message) Fingerprint() (f Hash, err error) {
 
 // String converts a message to a nice string
 func (m Message) String() string {
-	var typeStr string
-	switch m.Type {
-	case ERROR_RESPONSE:
-		typeStr = "ERROR_RESPONSE"
-	case OK_RESPONSE:
-		typeStr = "OK_RESPONSE"
-	case PUT_REQUEST:
-		typeStr = "PUT_REQUEST"
-	case DEL_REQUEST:
-		typeStr = "DEL_REQUEST"
-	case MOD_REQUEST:
-		typeStr = "MOD_REQUEST"
-	case GET_REQUEST:
-		typeStr = "GET_REQUEST"
-	case LINK_REQUEST:
-		typeStr = "LINK_REQUEST"
-	case GETLINK_REQUEST:
-		typeStr = "GETLINK_REQUEST"
-	case DELETELINK_REQUEST:
-		typeStr = "DELETELINK_REQUEST"
-	case GOSSIP_REQUEST:
-		typeStr = "GOSSIP_REQUEST"
-	case VALIDATE_PUT_REQUEST:
-		typeStr = "VALIDATE_PUT_REQUEST"
-	case VALIDATE_LINK_REQUEST:
-		typeStr = "VALIDATE_LINK_REQUEST"
-	case VALIDATE_DEL_REQUEST:
-		typeStr = "VALIDATE_DEL_REQUEST"
-	case VALIDATE_MOD_REQUEST:
-		typeStr = "VALIDATE_MOD_REQUEST"
-	case APP_MESSAGE:
-		typeStr = "APP_MESSAGE"
-	case LISTADD_REQUEST:
-		typeStr = "LISTADD_REQUEST"
-	case FIND_NODE_REQUEST:
-		typeStr = "FIND_NODE_REQUEST"
-	}
-	return fmt.Sprintf("%s @ %v From:%v Body:%v", typeStr, m.Time, m.From, m.Body)
+	return fmt.Sprintf("%v @ %v From:%v Body:%v", m.Type, m.Time, m.From, m.Body)
 }
 
 // respondWith writes a message either error or otherwise, to the stream

--- a/service.go
+++ b/service.go
@@ -1429,7 +1429,7 @@ func TestingAppScaffold() string {
         "Zome":   "zySampleZome",
         "FnName": "addEven",
         "Input":  "5",
-        "Err":    "Error calling 'commit': Invalid entry: 5"},
+        "Err":    "Error calling 'commit': Validation Failed"},
     {
         "Zome":   "zySampleZome",
         "FnName": "addPrime",
@@ -1439,7 +1439,7 @@ func TestingAppScaffold() string {
         "Zome":   "zySampleZome",
         "FnName": "addPrime",
         "Input":  {"prime":4},
-        "Err":    "Error calling 'commit': Invalid entry: {\"prime\":4}"},
+        "Err":    "Error calling 'commit': Validation Failed"},
     {
 	"Zome":   "jsSampleZome",
 	"FnName": "addProfile",
@@ -1469,7 +1469,7 @@ func TestingAppScaffold() string {
 	"Zome":   "jsSampleZome",
 	"FnName": "addOdd",
 	"Input":  "2",
-	"Err":    "Invalid entry: 2"},
+	"Err":    "Validation Failed"},
     {
 	"Zome":   "zySampleZome",
 	"FnName": "confirmOdd",

--- a/zygosome.go
+++ b/zygosome.go
@@ -310,9 +310,6 @@ func (z *ZygoRibosome) validateEntry(fnName string, def *EntryDef, entry Entry, 
 	Debugf("%s: %s", fnName, code)
 
 	err = z.runValidate(fnName, code)
-	if err != nil && err == ValidationFailedErr {
-		err = fmt.Errorf("Invalid entry: %v", entry.Content())
-	}
 	return
 }
 


### PR DESCRIPTION
This pull request fixes many holes in sys validation.  Still to do, is think through what use the package would have for validating key and agent on revocation.  That's added as a separate ticket: #440

also fixes #438 (bogus inclusion of entry in error message)