### PR TITLE
Redact private chain entries in validation package, closes #352

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -25,10 +25,12 @@ var ErrHashNotFound = errors.New("hash not found")
 var ErrIncompleteChain = errors.New("operation not allowed on incomplete chain")
 
 const (
-	ChainMarshalFlagsNone      = 0x00
-	ChainMarshalFlagsNoHeaders = 0x01
-	ChainMarshalFlagsNoEntries = 0x02
-	ChainMarshalFlagsOmitDNA   = 0x04
+	ChainMarshalFlagsNone            = 0x00
+	ChainMarshalFlagsNoHeaders       = 0x01
+	ChainMarshalFlagsNoEntries       = 0x02
+	ChainMarshalFlagsOmitDNA         = 0x04
+	ChainMarshalFlagsNoPrivate       = 0x08
+	ChainMarshalPrivateEntryRedacted = "%%PRIVATE ENTRY REDACTED%%"
 )
 
 // Chain structure for providing in-memory access to chain data, entries headers and hashes
@@ -343,6 +345,10 @@ func (c *Chain) MarshalChain(writer io.Writer, flags int64, whitelistTypes []str
 
 			if (flags & ChainMarshalFlagsNoEntries) != 0 {
 				e = nil
+			}
+
+			if !filterPass(i, hdr, whitelistTypes, privateTypes) {
+				e = &GobEntry{C: ChainMarshalPrivateEntryRedacted}
 			}
 
 			if (flags & ChainMarshalFlagsNoHeaders) != 0 {

--- a/chain_test.go
+++ b/chain_test.go
@@ -199,6 +199,9 @@ func TestMarshalChain(t *testing.T) {
 	e = GobEntry{C: "and more data"}
 	c.AddEntry(now, "entryTypeFoo3", &e, key)
 
+	e = GobEntry{C: "some private"}
+	c.AddEntry(now, "entryTypePrivate", &e, key)
+
 	Convey("it should be able to marshal and unmarshal full chain", t, func() {
 		var b bytes.Buffer
 
@@ -297,6 +300,25 @@ func TestMarshalChain(t *testing.T) {
 		So(reflect.DeepEqual(c.Hmap, c1.Hmap), ShouldBeTrue)
 		So(reflect.DeepEqual(c.Emap, c1.Emap), ShouldBeTrue)
 		So(reflect.DeepEqual(c.Entries, c1.Entries), ShouldBeTrue)
+
+	})
+
+	Convey("it should be able to marshal with contents of private entries being redacted", t, func() {
+		var b bytes.Buffer
+
+		privateTypes := []string{"entryTypePrivate"}
+		err := c.MarshalChain(&b, ChainMarshalFlagsNone, emptyStringList, privateTypes)
+		So(err, ShouldBeNil)
+		_, c1, err := UnmarshalChain(hashSpec, &b)
+		So(err, ShouldBeNil)
+		So(len(c1.Headers), ShouldEqual, len(c.Headers))
+		So(len(c1.Entries), ShouldEqual, len(c.Entries))
+		So(c1.Entries[0].Content(), ShouldEqual, c.Entries[0].Content())
+		So(c1.Entries[1].Content(), ShouldEqual, c.Entries[1].Content())
+		So(c1.Entries[2].Content(), ShouldEqual, c.Entries[2].Content())
+		So(c1.Entries[3].Content(), ShouldEqual, c.Entries[3].Content())
+		So(c1.Entries[4].Content(), ShouldEqual, c.Entries[4].Content())
+		So(c1.Entries[5].Content(), ShouldEqual, ChainMarshalPrivateEntryRedacted)
 
 	})
 

--- a/chain_test.go
+++ b/chain_test.go
@@ -182,6 +182,7 @@ func TestGet(t *testing.T) {
 func TestMarshalChain(t *testing.T) {
 	hashSpec, key, now := chainTestSetup()
 	c := NewChain(hashSpec)
+	var emptyStringList []string
 
 	e := GobEntry{C: "fake DNA"}
 	c.AddEntry(now, DNAEntryType, &e, key)
@@ -201,7 +202,7 @@ func TestMarshalChain(t *testing.T) {
 	Convey("it should be able to marshal and unmarshal full chain", t, func() {
 		var b bytes.Buffer
 
-		err := c.MarshalChain(&b, ChainMarshalFlagsNone)
+		err := c.MarshalChain(&b, ChainMarshalFlagsNone, emptyStringList, emptyStringList)
 		So(err, ShouldBeNil)
 		flags, c1, err := UnmarshalChain(hashSpec, &b)
 		So(err, ShouldBeNil)
@@ -221,7 +222,8 @@ func TestMarshalChain(t *testing.T) {
 	Convey("it should be able to marshal and unmarshal specify types", t, func() {
 		var b bytes.Buffer
 
-		err := c.MarshalChain(&b, ChainMarshalFlagsNone, AgentEntryType, "entryTypeFoo2")
+		typeList := []string{AgentEntryType, "entryTypeFoo2"}
+		err := c.MarshalChain(&b, ChainMarshalFlagsNone, typeList, emptyStringList)
 		So(err, ShouldBeNil)
 		flags, c1, err := UnmarshalChain(hashSpec, &b)
 		So(err, ShouldBeNil)
@@ -237,7 +239,7 @@ func TestMarshalChain(t *testing.T) {
 	Convey("it should be able to marshal and unmarshal headers only", t, func() {
 		var b bytes.Buffer
 
-		err := c.MarshalChain(&b, ChainMarshalFlagsNoEntries)
+		err := c.MarshalChain(&b, ChainMarshalFlagsNoEntries, emptyStringList, emptyStringList)
 		So(err, ShouldBeNil)
 		flags, c1, err := UnmarshalChain(hashSpec, &b)
 		So(err, ShouldBeNil)
@@ -259,7 +261,7 @@ func TestMarshalChain(t *testing.T) {
 	Convey("it should be able to marshal and unmarshal entries only", t, func() {
 		var b bytes.Buffer
 
-		err := c.MarshalChain(&b, ChainMarshalFlagsNoHeaders)
+		err := c.MarshalChain(&b, ChainMarshalFlagsNoHeaders, emptyStringList, emptyStringList)
 		So(err, ShouldBeNil)
 		flags, c1, err := UnmarshalChain(hashSpec, &b)
 		So(err, ShouldBeNil)
@@ -278,7 +280,7 @@ func TestMarshalChain(t *testing.T) {
 	Convey("it should be able to marshal and unmarshal with omitted DNA", t, func() {
 		var b bytes.Buffer
 
-		err := c.MarshalChain(&b, ChainMarshalFlagsOmitDNA)
+		err := c.MarshalChain(&b, ChainMarshalFlagsOmitDNA, emptyStringList, emptyStringList)
 		So(err, ShouldBeNil)
 		flags, c1, err := UnmarshalChain(hashSpec, &b)
 		So(err, ShouldBeNil)

--- a/entry.go
+++ b/entry.go
@@ -40,6 +40,7 @@ const (
 
 	Public  = "public"
 	Partial = "partial"
+	Private = "private"
 )
 
 // AgentEntry structure for building AgentEntryType entries

--- a/holochain.go
+++ b/holochain.go
@@ -584,6 +584,14 @@ func (h *Holochain) GetEntryDef(t string) (zome *Zome, d *EntryDef, err error) {
 	return
 }
 
+func (h *Holochain) GetPrivateEntryDefs() (privateDefs []EntryDef) {
+	privateDefs = make([]EntryDef, 0)
+	for _, z := range h.nucleus.dna.Zomes {
+		privateDefs = append(privateDefs, z.GetPrivateEntryDefs()...)
+	}
+	return
+}
+
 // Call executes an exposed function
 func (h *Holochain) Call(zomeType string, function string, arguments interface{}, exposureContext string) (result interface{}, err error) {
 	n, z, err := h.MakeRibosome(zomeType)

--- a/holochain_test.go
+++ b/holochain_test.go
@@ -712,6 +712,23 @@ func TestGetEntryDef(t *testing.T) {
 		So(zome, ShouldBeNil)
 		So(def, ShouldEqual, KeyEntryDef)
 	})
+	Convey("it should get private entry definition", t, func() {
+		zome, def, err := h.GetEntryDef("privateData")
+		So(err, ShouldBeNil)
+		So(zome, ShouldNotBeNil)
+		So(def, ShouldNotBeNil)
+	})
+}
+
+func TestGetPrivateEntryDefs(t *testing.T) {
+	d, _, h := SetupTestChain("test")
+	defer CleanupTestDir(d)
+	Convey("it should contain only private entry definition", t, func() {
+		_, privateData, _ := h.GetEntryDef("privateData")
+		privateDefs := h.GetPrivateEntryDefs()
+		So(len(privateDefs), ShouldEqual, 1)
+		So(privateDefs[0].Name, ShouldEqual, privateData.Name)
+	})
 }
 
 //func TestDNADefaults(t *testing.T) {

--- a/service.go
+++ b/service.go
@@ -1296,6 +1296,11 @@ func TestingAppScaffold() string {
                     "DataFormat": "json",
                     "Schema": "` + jsSanitizeString(profileSchema) + `",
                     "Sharing": "public"
+                },
+                {
+                  "Name": "privateData",
+                  "DataFormat": "string",
+                  "Sharing": "private"
                 }
             ],
             "Functions": [

--- a/validate.go
+++ b/validate.go
@@ -84,7 +84,9 @@ func MakePackage(h *Holochain, req PackagingReq) (pkg Package, err error) {
 		if t, ok := req[PkgReqEntryTypes]; ok {
 			types = t.([]string)
 		}
-		h.chain.MarshalChain(&b, mflags+ChainMarshalFlagsOmitDNA, types...)
+		var emptyStringList []string
+
+		h.chain.MarshalChain(&b, mflags+ChainMarshalFlagsOmitDNA, types, emptyStringList)
 		pkg.Chain = b.Bytes()
 	}
 	return

--- a/validate.go
+++ b/validate.go
@@ -84,9 +84,14 @@ func MakePackage(h *Holochain, req PackagingReq) (pkg Package, err error) {
 		if t, ok := req[PkgReqEntryTypes]; ok {
 			types = t.([]string)
 		}
-		var emptyStringList []string
 
-		h.chain.MarshalChain(&b, mflags+ChainMarshalFlagsOmitDNA, types, emptyStringList)
+		privateEntries := h.GetPrivateEntryDefs()
+		privateTypeNames := make([]string, len(privateEntries))
+		for i, def := range privateEntries {
+			privateTypeNames[i] = def.Name
+		}
+
+		h.chain.MarshalChain(&b, mflags+ChainMarshalFlagsOmitDNA, types, privateTypeNames)
 		pkg.Chain = b.Bytes()
 	}
 	return

--- a/validate_test.go
+++ b/validate_test.go
@@ -128,6 +128,22 @@ func TestMakePackage(t *testing.T) {
 		So(string(pkg.Chain), ShouldEqual, string(b.Bytes()))
 	})
 
+	Convey("it should not contain the real contents of private entries", t, func() {
+		entry := GobEntry{C: "secret message"}
+		h.NewEntry(time.Now(), "privateData", &entry)
+
+		req := PackagingReq{PkgReqChain: int64(PkgReqChainOptFull)}
+		pkg, err := MakePackage(h, req)
+		So(err, ShouldBeNil)
+
+		_, c1, err := UnmarshalChain(h.hashSpec, bytes.NewBuffer(pkg.Chain))
+		So(err, ShouldBeNil)
+		So(c1.Entries[2].Content(), ShouldEqual, "2") //from previous test cases
+		So(c1.Entries[3].Content(), ShouldEqual, "3") //from previous test cases
+		So(c1.Entries[4].Content(), ShouldNotEqual, "secret message")
+		So(c1.Entries[4].Content(), ShouldEqual, ChainMarshalPrivateEntryRedacted)
+	})
+
 }
 
 func TestGetValidationResponse(t *testing.T) {

--- a/validate_test.go
+++ b/validate_test.go
@@ -83,6 +83,7 @@ func TestValidateReceiver(t *testing.T) {
 func TestMakePackage(t *testing.T) {
 	d, _, h := PrepareTestChain("test")
 	defer CleanupTestChain(h, d)
+	var emptyStringList []string
 
 	Convey("it should be able to make a full chain package", t, func() {
 		req := PackagingReq{PkgReqChain: int64(PkgReqChainOptFull)}
@@ -90,7 +91,7 @@ func TestMakePackage(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		var b bytes.Buffer
-		h.chain.MarshalChain(&b, ChainMarshalFlagsOmitDNA)
+		h.chain.MarshalChain(&b, ChainMarshalFlagsOmitDNA, emptyStringList, emptyStringList)
 		So(string(pkg.Chain), ShouldEqual, string(b.Bytes()))
 	})
 	Convey("it should be able to make a headers only chain package", t, func() {
@@ -99,7 +100,7 @@ func TestMakePackage(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		var b bytes.Buffer
-		h.chain.MarshalChain(&b, ChainMarshalFlagsNoEntries+ChainMarshalFlagsOmitDNA)
+		h.chain.MarshalChain(&b, ChainMarshalFlagsNoEntries+ChainMarshalFlagsOmitDNA, emptyStringList, emptyStringList)
 		So(string(pkg.Chain), ShouldEqual, string(b.Bytes()))
 	})
 	Convey("it should be able to make an entries only chain package", t, func() {
@@ -108,7 +109,7 @@ func TestMakePackage(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		var b bytes.Buffer
-		h.chain.MarshalChain(&b, ChainMarshalFlagsNoHeaders+ChainMarshalFlagsOmitDNA)
+		h.chain.MarshalChain(&b, ChainMarshalFlagsNoHeaders+ChainMarshalFlagsOmitDNA, emptyStringList, emptyStringList)
 		So(string(pkg.Chain), ShouldEqual, string(b.Bytes()))
 	})
 
@@ -123,7 +124,7 @@ func TestMakePackage(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		var b bytes.Buffer
-		h.chain.MarshalChain(&b, ChainMarshalFlagsOmitDNA, "oddNumbers")
+		h.chain.MarshalChain(&b, ChainMarshalFlagsOmitDNA, []string{"oddNumbers"}, emptyStringList)
 		So(string(pkg.Chain), ShouldEqual, string(b.Bytes()))
 	})
 
@@ -132,6 +133,7 @@ func TestMakePackage(t *testing.T) {
 func TestGetValidationResponse(t *testing.T) {
 	d, _, h := PrepareTestChain("test")
 	defer CleanupTestChain(h, d)
+	var emptyStringList []string
 
 	hash := commit(h, "oddNumbers", "3")
 
@@ -146,7 +148,7 @@ func TestGetValidationResponse(t *testing.T) {
 		So(resp.Type, ShouldEqual, "oddNumbers")
 		So(fmt.Sprintf("%v", &resp.Entry), ShouldEqual, fmt.Sprintf("%v", entry))
 		var b bytes.Buffer
-		h.chain.MarshalChain(&b, ChainMarshalFlagsOmitDNA)
+		h.chain.MarshalChain(&b, ChainMarshalFlagsOmitDNA, emptyStringList, emptyStringList)
 		So(fmt.Sprintf("%v", string(resp.Package.Chain)), ShouldEqual, fmt.Sprintf("%v", string(b.Bytes())))
 	})
 
@@ -168,7 +170,7 @@ func TestGetValidationResponse(t *testing.T) {
 
 		types := []string{AgentEntryType}
 		var b bytes.Buffer
-		h.chain.MarshalChain(&b, ChainMarshalFlagsOmitDNA, types...)
+		h.chain.MarshalChain(&b, ChainMarshalFlagsOmitDNA, types, emptyStringList)
 		So(fmt.Sprintf("%v", string(resp.Package.Chain)), ShouldEqual, fmt.Sprintf("%v", string(b.Bytes())))
 	})
 

--- a/zome.go
+++ b/zome.go
@@ -35,6 +35,16 @@ func (z *Zome) GetEntryDef(entryName string) (e *EntryDef, err error) {
 	return
 }
 
+func (z *Zome) GetPrivateEntryDefs() (privateDefs []EntryDef) {
+	privateDefs = make([]EntryDef, 0)
+	for _, def := range z.Entries {
+		if def.Sharing == "private" {
+			privateDefs = append(privateDefs, def)
+		}
+	}
+	return
+}
+
 // GetFunctionDef returns the exposed function spec for the given zome and function
 func (zome *Zome) GetFunctionDef(fnName string) (fn *FunctionDef, err error) {
 	for _, f := range zome.Functions {


### PR DESCRIPTION
* Get names of all private types (from all zomes)
* In MarshalChain, check for every entry if it is private and replace the content with a hard coded censor string
* Had to refactor MarshalChain() for this.