### PR TITLE
standardized -debug flag behvior and fixed bugs, closes #484

### DIFF
--- a/cmd/hcadmin/hcadmin.go
+++ b/cmd/hcadmin/hcadmin.go
@@ -215,8 +215,6 @@ func setupApp() (app *cli.App) {
 	app.Before = func(c *cli.Context) error {
 		if debug {
 			os.Setenv("HCLOG_APP_ENABLE", "1")
-			os.Setenv("HCLOG_DHT_ENABLE", "1")
-			os.Setenv("HCLOG_GOSSIP_ENABLE", "1")
 		}
 		if verbose {
 			fmt.Printf("hcadmin version %s \n", app.Version)

--- a/cmd/hcadmin/hcadmin_test.go
+++ b/cmd/hcadmin/hcadmin_test.go
@@ -1,13 +1,11 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	holo "github.com/metacurrency/holochain"
 	"github.com/metacurrency/holochain/cmd"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/urfave/cli"
-	"io"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -130,13 +128,13 @@ func TestBridge(t *testing.T) {
 
 	Convey("it should bridge chains", t, func() {
 		app = setupApp()
-		out, err := runAppWithStdoutCapture(app, []string{"hcadmin", "-path", d, "bridge", "testApp1", "testApp2", "-bridgeToAppData", "some to app data"})
+		out, err := runAppWithStdoutCapture(app, []string{"hcadmin", "-debug", "-path", d, "bridge", "testApp1", "testApp2", "-bridgeToAppData", "some to app data"})
 		So(err, ShouldBeNil)
 		So(out, ShouldContainSubstring, "bridge genesis to-- other side is:"+testApp1DNA+" bridging data:some to app data\n")
 	})
 	Convey("after bridge status should show it", t, func() {
 		app = setupApp()
-		out, err := runAppWithStdoutCapture(app, []string{"hcadmin", "-path", d, "status"})
+		out, err := runAppWithStdoutCapture(app, []string{"hcadmin", "-debug", "-path", d, "status"})
 		So(err, ShouldBeNil)
 		So(out, ShouldContainSubstring, "testApp1 "+testApp1DNA+"\n        bridged to: "+testApp2DNA)
 		So(out, ShouldContainSubstring, "testApp2 "+testApp2DNA+"\n        bridged from by token:")
@@ -144,26 +142,5 @@ func TestBridge(t *testing.T) {
 }
 
 func runAppWithStdoutCapture(app *cli.App, args []string) (out string, err error) {
-	os.Args = args
-
-	old := os.Stdout // keep backup of the real stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	go func() { err = app.Run(os.Args) }()
-	time.Sleep(time.Second * 5)
-
-	outC := make(chan string)
-	// copy the output in a separate goroutine so printing can't block indefinitely
-	go func() {
-		var buf bytes.Buffer
-		io.Copy(&buf, r)
-		outC <- buf.String()
-	}()
-
-	// back to normal state
-	w.Close()
-	os.Stdout = old // restoring the real stdout
-	out = <-outC
-	return
+	return cmd.RunAppWithStdoutCapture(app, args, time.Second*5)
 }

--- a/cmd/hcd/hcd.go
+++ b/cmd/hcd/hcd.go
@@ -49,19 +49,15 @@ func setupApp() (app *cli.App) {
 			Usage:       "verbose output",
 			Destination: &verbose,
 		},
-		cli.BoolFlag{
-			Name:        "no-nat-upnp",
-			Usage:       "whether to stop hcd from creating a port mapping through NAT via UPnP",
-			Destination: &nonatupnp,
-		},
 	}
 
 	app.Before = func(c *cli.Context) error {
+		// for hcd the -debug flag enables the app level debugging
 		if debug {
-			os.Setenv("DEBUG", "1")
+			os.Setenv("HCLOG_APP_ENABLE", "1")
 		}
 		if verbose {
-			fmt.Printf("hc version %s \n", app.Version)
+			fmt.Printf("hcd version %s \n", app.Version)
 		}
 		var err error
 		root, err = cmd.GetHolochainRoot(root)
@@ -71,12 +67,6 @@ func setupApp() (app *cli.App) {
 		service, err = cmd.GetService(root)
 		if err != nil {
 			return err
-		}
-		if nonatupnp == false {
-			err = os.Setenv("HOLOCHAINCONFIG_ENABLENATUPNP", "true")
-			if err != nil {
-				return err
-			}
 		}
 		return nil
 	}
@@ -105,9 +95,7 @@ func setupApp() (app *cli.App) {
 
 			h.StartBackgroundTasks()
 
-			if verbose {
-				fmt.Printf("Serving holochain with DNA hash:%v on port %s\n", h.DNAHash(), port)
-			}
+			fmt.Printf("Serving holochain with DNA hash:%v on port %s\n", h.DNAHash(), port)
 
 			ws := ui.NewWebServer(h, port)
 			ws.Start()

--- a/cmd/hcdev/hcdev.go
+++ b/cmd/hcdev/hcdev.go
@@ -125,7 +125,7 @@ func setupApp() (app *cli.App) {
 		},
 		cli.StringFlag{
 			Name:        "port",
-			Usage:       "port on which to run the... something",
+			Usage:       "port on which to run the test/scenario instance",
 			Destination: &port,
 		},
 		cli.BoolFlag{
@@ -806,8 +806,9 @@ func setupApp() (app *cli.App) {
 
 		holo.Debugf("args:%v\n", c.Args())
 
+		// hcdev always enables the app debugging, and the -debug flag enables the holochain debugging
+		os.Setenv("HCLOG_APP_ENABLE", "1")
 		if debug {
-			os.Setenv("HCLOG_APP_ENABLE", "1")
 			os.Setenv("HCLOG_DHT_ENABLE", "1")
 			os.Setenv("HCLOG_GOSSIP_ENABLE", "1")
 			os.Setenv("HCLOG_DEBUG_ENABLE", "1")

--- a/cmd/hcdev/hcdev_test.go
+++ b/cmd/hcdev/hcdev_test.go
@@ -1,14 +1,12 @@
 package main
 
 import (
-	"bytes"
 	"fmt"
 	"github.com/davecgh/go-spew/spew"
 	holo "github.com/metacurrency/holochain"
 	"github.com/metacurrency/holochain/cmd"
 	. "github.com/smartystreets/goconvey/convey"
 	"github.com/urfave/cli"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -181,7 +179,7 @@ func TestPackage(t *testing.T) {
 	tmpTestDir, app := setupTestingApp("foo")
 	defer os.RemoveAll(tmpTestDir)
 	Convey("'package' should print a scaffold file to stdout", t, func() {
-		scaffold, err := runAppWithStdoutCapture(app, []string{"hcdev", "package"}, 2*time.Second)
+		scaffold, err := cmd.RunAppWithStdoutCapture(app, []string{"hcdev", "package"}, 2*time.Second)
 		So(err, ShouldBeNil)
 		So(scaffold, ShouldContainSubstring, fmt.Sprintf(`"ScaffoldVersion": "%s"`, holo.ScaffoldVersion))
 	})
@@ -189,7 +187,7 @@ func TestPackage(t *testing.T) {
 	d := holo.SetupTestDir()
 	defer os.RemoveAll(d)
 	Convey("'package' should output a scaffold file to file", t, func() {
-		runAppWithStdoutCapture(app, []string{"hcdev", "package", filepath.Join(d, "scaff.json")}, 2*time.Second)
+		cmd.RunAppWithStdoutCapture(app, []string{"hcdev", "package", filepath.Join(d, "scaff.json")}, 2*time.Second)
 		scaffold, err := holo.ReadFile(d, "scaff.json")
 		So(err, ShouldBeNil)
 		So(string(scaffold), ShouldContainSubstring, fmt.Sprintf(`"ScaffoldVersion": "%s"`, holo.ScaffoldVersion))
@@ -203,44 +201,29 @@ func TestWeb(t *testing.T) {
 	defer os.RemoveAll(tmpTestDir)
 
 	Convey("'web' should run a webserver", t, func() {
-		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "web"}, 30*time.Second)
+		out, err := cmd.RunAppWithStdoutCapture(app, []string{"hcdev", "-no-nat-upnp", "web"}, 5*time.Second)
 		So(err, ShouldBeNil)
 		So(out, ShouldContainSubstring, "on port:4141")
 		So(out, ShouldContainSubstring, "Serving holochain with DNA hash:")
+		// it should include app level debug but not holochain debug
+		So(out, ShouldContainSubstring, "running zyZome genesis")
+		So(out, ShouldNotContainSubstring, "NewEntry of %dna added as: QmR")
+	})
+	app = setupApp()
+
+	Convey("'web -debug' should run a webserver and include holochain debug info", t, func() {
+		out, err := cmd.RunAppWithStdoutCapture(app, []string{"hcdev", "-debug", "-no-nat-upnp", "web", "4142"}, 5*time.Second)
+		So(err, ShouldBeNil)
+		So(out, ShouldContainSubstring, "running zyZome genesis")
+		So(out, ShouldContainSubstring, "NewEntry of %dna added as: Qm")
 	})
 	app = setupApp()
 
 	Convey("'web' not in an app directory should produce error", t, func() {
-		out, err := runAppWithStdoutCapture(app, []string{"hcdev", "-path", tmpTestDir, "web"}, 1*time.Second)
+		out, err := cmd.RunAppWithStdoutCapture(app, []string{"hcdev", "-path", tmpTestDir, "web"}, 1*time.Second)
 		So(err, ShouldBeError)
 		So(out, ShouldContainSubstring, "doesn't look like a holochain app")
 	})
-}
-
-func runAppWithStdoutCapture(app *cli.App, args []string, wait time.Duration) (out string, err error) {
-	os.Args = args
-
-	old := os.Stdout // keep backup of the real stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	go func() { err = app.Run(os.Args) }()
-
-	outC := make(chan string)
-	// copy the output in a separate goroutine so printing can't block indefinitely
-	go func() {
-		var buf bytes.Buffer
-		io.Copy(&buf, r)
-		outC <- buf.String()
-	}()
-
-	time.Sleep(wait)
-
-	// back to normal state
-	w.Close()
-	os.Stdout = old // restoring the real stdout
-	out = <-outC
-	return
 }
 
 func setupTestingApp(name string) (string, *cli.App) {
@@ -260,6 +243,11 @@ func setupTestingApp(name string) (string, *cli.App) {
 	if err != nil {
 		panic(err)
 	}
+
+	// cleanup env flags set
+	os.Unsetenv("HOLOCHAINCONFIG_ENABLENATUPNP")
+	os.Unsetenv("HOLOCHAINCONFIG_BOOTSTRAP")
+	os.Unsetenv("HOLOCHAINCONFIG_ENABLEMDNS")
 
 	err = os.Chdir(filepath.Join(tmpTestDir, name))
 	if err != nil {

--- a/holochain_test.go
+++ b/holochain_test.go
@@ -82,7 +82,7 @@ func TestSetupLogging(t *testing.T) {
 		err := h.Config.SetupLogging()
 		So(err, ShouldBeNil)
 		// test some default configurations
-		So(h.Config.Loggers.App.Enabled, ShouldBeTrue)
+		So(h.Config.Loggers.App.Enabled, ShouldBeFalse)
 		So(h.Config.Loggers.DHT.Enabled, ShouldBeFalse)
 		So(h.Config.Loggers.Gossip.Enabled, ShouldBeFalse)
 		So(h.Config.Loggers.TestFailed.w, ShouldEqual, os.Stderr)

--- a/node.go
+++ b/node.go
@@ -519,7 +519,6 @@ func (node *Node) Send(ctx context.Context, proto int, addr peer.ID, m *Message)
 
 	s, err := node.host.NewStream(ctx, addr, node.protocols[proto].ID)
 	if err != nil {
-		fmt.Printf("SENDERR in %v sending to%v:%v\n", node.HashAddr, addr, err)
 		return
 	}
 	defer s.Close()


### PR DESCRIPTION
So the expected behavior now is that for

`hcdev`: defaults to outputing all application level debug statements and -debug outputs holochain level debug data

`hcadmin` & `hcd`: defaults to no output and -debug outputs app level debug.  For holochain level debug you can use the HC_ENABLE env vars.

Note this commit  also removes -no-nat-upnp flag from `hcd` which didn't work anyways (the envrionment flag it set is only used during config initialization i.e. join time)

The commit includes some refactoring of testing code, and cleanup of other ENV variable stuff in holochain.