### PR TITLE
added checks to calling type for interpreting test Input/Output vals, closes #489

### DIFF
--- a/apptest/apptest_test.go
+++ b/apptest/apptest_test.go
@@ -54,6 +54,9 @@ func TestTestStringReplacements(t *testing.T) {
 		input = "%result99%"
 		output = testStringReplacements(input, &replacements)
 		So(output, ShouldEqual, "<bad-result-index>")
+		input = "{\"%result%\":0}"
+		output = testStringReplacements(input, &replacements)
+		So(output, ShouldEqual, "foo")
 	})
 }
 
@@ -93,14 +96,6 @@ func TestTest(t *testing.T) {
 		So(err, ShouldBeNil)
 	})
 
-	Convey("it should fail the test on incorrect input types", t, func() {
-		os.Remove(filepath.Join(d, ".holochain", "test", "test", "test_0.json"))
-		err := WriteFile([]byte(`[{"Zome":"zySampleZome","FnName":"addEven","Input":2,"Output":"%h%","Err":""}]`), d, ".holochain", "test", "test", "test_0.json")
-		So(err, ShouldBeNil)
-		err = Test(h, nil)[0]
-		So(err, ShouldNotBeNil)
-		So(err.Error(), ShouldEqual, "Input was not an expected type: float64")
-	})
 	Convey("it should fail the test on incorrect data", t, func() {
 		os.Remove(filepath.Join(d, ".holochain", "test", "test", "test_0.json"))
 		err := WriteFile([]byte(`[{"Zome":"zySampleZome","FnName":"addEven","Input":"2","Output":"","Err":"bogus error"}]`), d, ".holochain", "test", "test", "test_0.json")

--- a/holochain.go
+++ b/holochain.go
@@ -30,10 +30,10 @@ import (
 
 const (
 	// Version is the numeric version number of the holochain library
-	Version int = 17
+	Version int = 18
 
 	// VersionStr is the textual version number of the holochain library
-	VersionStr string = "17"
+	VersionStr string = "18"
 
 	// DefaultSendTimeout a time.Duration to wait by default for send to complete
 	DefaultSendTimeout = 3000 * time.Millisecond

--- a/service.go
+++ b/service.go
@@ -127,7 +127,7 @@ type TestData struct {
 	Zome     string        // the zome in which to find the function
 	FnName   string        // the function to call
 	Input    interface{}   // the function's input
-	Output   string        // the expected output to match against (full match)
+	Output   interface{}   // the expected output to match against (full match)
 	Err      string        // the expected error to match against
 	Regexp   string        // the expected out to match again (regular expression)
 	Time     time.Duration // offset in milliseconds from the start of the test at which to run this test.
@@ -1482,7 +1482,7 @@ func TestingAppAppPackage() string {
         "Zome":   "zySampleZome",
         "FnName": "addPrime",
         "Input":  {"prime":7},
-        "Output": "\"%h%\""},
+        "Output": "%h%"},
     {
         "Zome":   "zySampleZome",
         "FnName": "addPrime",
@@ -1492,7 +1492,7 @@ func TestingAppAppPackage() string {
 	"Zome":   "jsSampleZome",
 	"FnName": "addProfile",
 	"Input":  {"firstName":"Art","lastName":"Brock"},
-	"Output": "\"%h%\""},
+	"Output": "%h%"},
     {
 	"Zome":   "zySampleZome",
 	"FnName": "getDNA",
@@ -1533,6 +1533,13 @@ func TestingAppAppPackage() string {
 	"Input":  "unexposed(\"this is a\")",
 	"Output": "this is a fish",
 	"Raw":    true
+    },
+    {
+	"Convey": "test the output of a function that returns json",
+	"Zome":   "jsSampleZome",
+	"FnName": "testJsonFn2",
+	"Input": "",
+	"Output": ["a":"b"]
     }
 ]}],
 "UI":[


### PR DESCRIPTION
This commit makes it so that in tests of functions defined as having JSON calling type, you can now specify  your input and output values to the test directly in test object not as JSON strings.  

Updated replacements to search for special object {"%result%":N} for replacing from the results history.  This is necessary because otherwise you couldn't replace a result that was itself an object in the test object, because that would show up as illegal JSON to the test object parser.

Bumped the internal version number to 18 so apps can set RequiredVersion for this feature.