### PR TITLE
tests now allow fixtures and config info, closes #502

### DIFF
--- a/app_package.go
+++ b/app_package.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	AppPackageVersion = "0.0.0"
+	AppPackageVersion = "0.0.1"
 )
 
 type AppPackageUIFile struct {
@@ -40,9 +40,9 @@ type AppPackage struct {
 }
 
 // LoadAppPackage decodes DNA and other appPackage data from appPackage file (via an io.reader)
-func LoadAppPackage(reader io.Reader) (appPackageP *AppPackage, err error) {
+func LoadAppPackage(reader io.Reader, encodingFormat string) (appPackageP *AppPackage, err error) {
 	var appPackage AppPackage
-	err = Decode(reader, "yml", &appPackage)
+	err = Decode(reader, encodingFormat, &appPackage)
 	if err != nil {
 		return
 	}
@@ -62,6 +62,10 @@ func LoadAppPackage(reader io.Reader) (appPackageP *AppPackage, err error) {
 `
 	return
 }
+
+const (
+	BasicTemplateAppPackageFormat = "yml"
+)
 
 var BasicTemplateAppPackage string = `{
  # AppPackage Version

--- a/app_package.go
+++ b/app_package.go
@@ -20,8 +20,8 @@ type AppPackageUIFile struct {
 }
 
 type AppPackageTests struct {
-	Name  string
-	Tests []TestData
+	Name    string
+	TestSet TestSet
 }
 
 type AppPackageScenario struct {
@@ -34,7 +34,7 @@ type AppPackage struct {
 	Version   string
 	Generator string
 	DNA       DNA
-	Tests     []AppPackageTests
+	TestSets  []AppPackageTests
 	UI        []AppPackageUIFile
 	Scenarios []AppPackageScenario
 }
@@ -168,9 +168,9 @@ var BasicTemplateAppPackage string = `{
       "Code": "'use strict';\n\n// -----------------------------------------------------------------\n//  This stub Zome code file was auto-generated\n// -----------------------------------------------------------------\n\n/**\n * Called only when your source chain is generated\n * @return {boolean} success\n */\nfunction genesis() {\n  // any genesis code here\n  return true;\n}\n\n// -----------------------------------------------------------------\n//  validation functions for every DHT entry change\n// -----------------------------------------------------------------\n\n/**\n * Called to validate any changes to the DHT\n * @param {string} entryName - the name of entry being modified\n * @param {*} entry - the entry data to be set\n * @param {?} header - ?\n * @param {?} pkg - ?\n * @param {?} sources - ?\n * @return {boolean} is valid?\n */\nfunction validateCommit (entryName, entry, header, pkg, sources) {\n  switch (entryName) {\n    case \"sampleEntry\":\n      // validation code here\n      return false;\n    default:\n      // invalid entry name!!\n      return false;\n  }\n}\n\n/**\n * Called to validate any changes to the DHT\n * @param {string} entryName - the name of entry being modified\n * @param {*}entry - the entry data to be set\n * @param {?} header - ?\n * @param {?} pkg - ?\n * @param {?} sources - ?\n * @return {boolean} is valid?\n */\nfunction validatePut (entryName, entry, header, pkg, sources) {\n  switch (entryName) {\n    case \"sampleEntry\":\n      // validation code here\n      return false;\ndefault:\n      // invalid entry name!!\n      return false;\n  }\n}\n\n/**\n * Called to validate any changes to the DHT\n * @param {string} entryName - the name of entry being modified\n * @param {*} entry- the entry data to be set\n * @param {?} header - ?\n * @param {*} replaces - the old entry data\n * @param {?} pkg - ?\n * @param {?} sources - ?\n * @return {boolean} is valid?\n */\nfunction validateMod (entryName, entry, header, replaces, pkg, sources) {\n  switch (entryName) {\n    case \"sampleEntry\":\n      // validation code here\n      return false;\n    default:\n      // invalid entry name!!\n      return false;\n  }\n}\n\n/**\n * Called to validate any changes to the DHT\n * @param {string} entryName - the name of entry being modified\n * @param {string} hash - the hash of the entry to remove\n * @param {?} pkg - ?\n * @param {?} sources - ?\n * @return {boolean} is valid?\n */\nfunction validateDel (entryName,hash, pkg, sources) {\n  switch (entryName) {\n    case \"sampleEntry\":\n      // validation code here\nreturn false;\n    default:\n      // invalid entry name!!\n      return false;\n  }\n}\n\n/**\n * Called to get the data needed to validate\n * @param {string} entryName - the name of entry to validate\n * @return {*} the data required for validation\n */\nfunction validatePutPkg (entryName) {\n  return null;\n}\n\n/**\n * Called to get the data needed to validate\n * @param {string} entryName - the name of entry to validate\n * @return {*} the data required for validation\n */\nfunction validateModPkg (entryName) {\n  return null;\n}\n\n/**\n * Called to get the data needed to validate\n * @param {string} entryName - the name of entry to validate\n * @return {*} the data required for validation\n */\nfunction validateDelPkg (entryName) {\n  return null;\n}"
     }
   ]},
-"Tests":[{
+"TestSets":[{
   "Name":"sample",
-  "Tests":[{"Convey":"We can create a new sampleEntry","FnName": "sampleEntryCreate","Input": {"body": "this is the entry body","stamp":12345},"Output":"\"%h1%\"","Exposure":"public"}]}
+  "TestSet":{"Tests":[{"Convey":"We can create a new sampleEntry","FnName": "sampleEntryCreate","Input": {"body": "this is the entry body","stamp":12345},"Output":"\"%h1%\"","Exposure":"public"}]}}
    ],
 "UI":[
 {"FileName":"index.html",

--- a/app_package.go
+++ b/app_package.go
@@ -183,11 +183,11 @@ var BasicTemplateAppPackage string = `{
         {"Name":"sampleScenario",
          "Roles":[
              {"Name":"listener",
-              "Tests":[
-                  {"Convey":"add listener test here"}]},
+              "TestSet":{"Tests":[
+                  {"Convey":"add listener test here"}]}},
              {"Name":"speaker",
-              "Tests":[
-                  {"Convey":"add speaker test here"}]}],
+              "TestSet":{"Tests":[
+                  {"Convey":"add speaker test here"}]}}],
          "Config":{"Duration":5,"GossipInterval":100}}]
 }
 `

--- a/app_package_test.go
+++ b/app_package_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestLoadAppPackage(t *testing.T) {
 	appPackageBlob := bytes.NewBuffer([]byte(BasicTemplateAppPackage))
-	appPackage, err := LoadAppPackage(appPackageBlob)
+	appPackage, err := LoadAppPackage(appPackageBlob, BasicTemplateAppPackageFormat)
 	Convey("it should load dna from a appPackage blob", t, func() {
 		So(err, ShouldBeNil)
 		dna := appPackage.DNA

--- a/app_package_test.go
+++ b/app_package_test.go
@@ -34,7 +34,11 @@ func TestLoadAppPackage(t *testing.T) {
 	Convey("it should load scenarios from a appPackage blob", t, func() {
 		So(appPackage.Scenarios[0].Name, ShouldEqual, "sampleScenario")
 		So(appPackage.Scenarios[0].Roles[0].Name, ShouldEqual, "listener")
+		So(len(appPackage.Scenarios[0].Roles[0].TestSet.Tests), ShouldEqual, 1)
+		So(appPackage.Scenarios[0].Roles[0].TestSet.Tests[0].Convey, ShouldEqual, "add listener test here")
 		So(appPackage.Scenarios[0].Roles[1].Name, ShouldEqual, "speaker")
+		So(len(appPackage.Scenarios[0].Roles[1].TestSet.Tests), ShouldEqual, 1)
+		So(appPackage.Scenarios[0].Roles[1].TestSet.Tests[0].Convey, ShouldEqual, "add speaker test here")
 		So(appPackage.Scenarios[0].Config.Duration, ShouldEqual, 5)
 		So(appPackage.Scenarios[0].Config.GossipInterval, ShouldEqual, 100)
 	})

--- a/app_package_test.go
+++ b/app_package_test.go
@@ -27,8 +27,8 @@ func TestLoadAppPackage(t *testing.T) {
 	})
 
 	Convey("it should load tests from a appPackage blob", t, func() {
-		So(appPackage.Tests[0].Name, ShouldEqual, "sample")
-		So(appPackage.Tests[0].Tests[0].Convey, ShouldEqual, "We can create a new sampleEntry")
+		So(appPackage.TestSets[0].Name, ShouldEqual, "sample")
+		So(appPackage.TestSets[0].TestSet.Tests[0].Convey, ShouldEqual, "We can create a new sampleEntry")
 	})
 
 	Convey("it should load scenarios from a appPackage blob", t, func() {

--- a/apptest/apptest_test.go
+++ b/apptest/apptest_test.go
@@ -98,7 +98,7 @@ func TestTest(t *testing.T) {
 
 	Convey("it should fail the test on incorrect data", t, func() {
 		os.Remove(filepath.Join(d, ".holochain", "test", "test", "test_0.json"))
-		err := WriteFile([]byte(`[{"Zome":"zySampleZome","FnName":"addEven","Input":"2","Output":"","Err":"bogus error"}]`), d, ".holochain", "test", "test", "test_0.json")
+		err := WriteFile([]byte(`{"Tests":[{"Zome":"zySampleZome","FnName":"addEven","Input":"2","Output":"","Err":"bogus error"}]}`), d, ".holochain", "test", "test", "test_0.json")
 		So(err, ShouldBeNil)
 		err = Test(h, nil)[0]
 		So(err, ShouldNotBeNil)
@@ -108,7 +108,7 @@ func TestTest(t *testing.T) {
 	Convey("it should fail the tests on code with zygo syntax errors", t, func() {
 		h.Nucleus().DNA().Zomes[0].Code += "badcode)("
 		errs := Test(h, nil)
-		So(len(errs), ShouldEqual, 11)
+		So(len(errs), ShouldEqual, 12)
 	})
 	Convey("it should fail the tests on code with js syntax errors", t, func() {
 		h.Nucleus().DNA().Zomes[1].Code += "badcode)("

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -297,14 +297,14 @@ func GetDuration_fromUnixTimestamp(timestamp int64) (duration time.Duration) {
 	return
 }
 
-func UpackageAppPackage(service *holo.Service, appPackagePath string, toPath string, appName string) (appPackage *holo.AppPackage, err error) {
+func UpackageAppPackage(service *holo.Service, appPackagePath string, toPath string, appName string, encodingFormat string) (appPackage *holo.AppPackage, err error) {
 	sf, err := os.Open(appPackagePath)
 	if err != nil {
 		return
 	}
 	defer sf.Close()
-	encodingFormat := holo.EncodingFormat(appPackagePath)
-	appPackage, err = service.SaveFromAppPackage(sf, toPath, appName, nil, encodingFormat, false)
+	decodingFormat := holo.EncodingFormat(appPackagePath)
+	appPackage, err = service.SaveFromAppPackage(sf, toPath, appName, nil, decodingFormat, encodingFormat, false)
 	return
 }
 

--- a/cmd/hcadmin/hcadmin.go
+++ b/cmd/hcadmin/hcadmin.go
@@ -130,7 +130,7 @@ func setupApp() (app *cli.App) {
 				if info.Mode().IsRegular() {
 
 					dstPath := filepath.Join(root, name)
-					_, err := cmd.UpackageAppPackage(service, srcPath, dstPath, name)
+					_, err := cmd.UpackageAppPackage(service, srcPath, dstPath, name, "json")
 
 					if err != nil {
 						return fmt.Errorf("join: error unpackaging %s: %v", srcPath, err)

--- a/cmd/hcadmin/hcadmin_test.go
+++ b/cmd/hcadmin/hcadmin_test.go
@@ -93,16 +93,16 @@ func TestJoinFromPackage(t *testing.T) {
 		panic(err)
 	}
 
-	err = holo.WriteFile([]byte(holo.BasicTemplateAppPackage), d, "appPackage.json")
+	err = holo.WriteFile([]byte(holo.BasicTemplateAppPackage), d, "appPackage."+holo.BasicTemplateAppPackageFormat)
 	if err != nil {
 		panic(err)
 	}
 	app = setupApp()
 	Convey("it should join a chain", t, func() {
-		out, err := runAppWithStdoutCapture(app, []string{"hcadmin", "-verbose", "-path", d, "join", filepath.Join(d, "appPackage.json"), "testApp"})
+		out, err := runAppWithStdoutCapture(app, []string{"hcadmin", "-verbose", "-path", d, "join", filepath.Join(d, "appPackage."+holo.BasicTemplateAppPackageFormat), "testApp"})
 		So(err, ShouldBeNil)
 		So(out, ShouldContainSubstring, fmt.Sprintf("hcadmin version %s \n", app.Version))
-		So(out, ShouldContainSubstring, fmt.Sprintf("joined testApp from %s/appPackage.json", d))
+		So(out, ShouldContainSubstring, fmt.Sprintf("joined testApp from %s/appPackage."+holo.BasicTemplateAppPackageFormat, d))
 		So(out, ShouldContainSubstring, "Genesis entries added and DNA hashed for new holochain with ID:")
 	})
 	app = setupApp()

--- a/cmd/hcdev/hcdev.go
+++ b/cmd/hcdev/hcdev.go
@@ -307,7 +307,7 @@ func setupApp() (app *cli.App) {
 
 				} else if appPackagePath != "" {
 					// build the app from the appPackage
-					_, err := cmd.UpackageAppPackage(service, appPackagePath, devPath, name)
+					_, err := cmd.UpackageAppPackage(service, appPackagePath, devPath, name, encodingFormat)
 					if err != nil {
 						return cmd.MakeErrFromErr(c, err)
 					}
@@ -329,7 +329,7 @@ func setupApp() (app *cli.App) {
 					}
 
 					var appPackage *holo.AppPackage
-					appPackage, err = service.SaveFromAppPackage(appPackageReader, devPath, name, agent, encodingFormat, true)
+					appPackage, err = service.SaveFromAppPackage(appPackageReader, devPath, name, agent, holo.BasicTemplateAppPackageFormat, encodingFormat, true)
 					if err != nil {
 						return cmd.MakeErrFromErr(c, err)
 					}

--- a/service.go
+++ b/service.go
@@ -1596,16 +1596,16 @@ func TestingAppAppPackage() string {
         {"Name":"sampleScenario",
          "Roles":[
              {"Name":"speaker",
-              "Tests":[
+              "TestSet":{"Tests":[
                   {"Convey":"add an odd",
                    "Zome":   "jsSampleZome",
 	           "FnName": "addOdd",
 	           "Input":  "7",
 	           "Output": "%h%"
                   }
-               ]},
+               ]}},
              {"Name":"listener",
-              "Tests":[
+              "TestSet":{"Tests":[
                   {"Convey":"confirm prime exists",
                    "Zome":   "zySampleZome",
 	           "FnName": "confirmOdd",
@@ -1613,7 +1613,7 @@ func TestingAppAppPackage() string {
 	           "Output": "true",
                    "Time" : 1500
                   }
-               ]},
+               ]}}
           ],
          "Config":{"Duration":5,"GossipInterval":300}}]
 }

--- a/service.go
+++ b/service.go
@@ -697,8 +697,7 @@ func (s *Service) MakeTestingApp(root string, encodingFormat string, initDB bool
 	appPackageReader := bytes.NewBuffer([]byte(TestingAppAppPackage()))
 
 	name := filepath.Base(root)
-
-	_, err = s.SaveFromAppPackage(appPackageReader, root, "test", agent, encodingFormat, newUUID)
+	_, err = s.SaveFromAppPackage(appPackageReader, root, "test", agent, TestingAppDecodingFormat, encodingFormat, newUUID)
 	if err != nil {
 		return
 	}
@@ -1076,8 +1075,8 @@ func encodeAsBinary(contentType string) bool {
 }
 
 // SaveFromAppPackage writes out a holochain application based on appPackage file to path
-func (service *Service) SaveFromAppPackage(reader io.Reader, path string, name string, agent Agent, encodingFormat string, newUUID bool) (appPackage *AppPackage, err error) {
-	appPackage, err = LoadAppPackage(reader)
+func (service *Service) SaveFromAppPackage(reader io.Reader, path string, name string, agent Agent, decodingFormat string, encodingFormat string, newUUID bool) (appPackage *AppPackage, err error) {
+	appPackage, err = LoadAppPackage(reader, decodingFormat)
 	if err != nil {
 		return
 	}
@@ -1313,6 +1312,10 @@ func GetAllTestRoles(path string) (roleNameList []string, err error) {
 	return
 }
 
+const (
+	TestingAppDecodingFormat = "json"
+)
+
 func TestingAppAppPackage() string {
 	return `{
 "Version": "` + AppPackageVersion + `",
@@ -1407,7 +1410,7 @@ func TestingAppAppPackage() string {
                 },
                 {
                     "Name": "myIdentity",
-                    "CallingType": "string",
+                    "CallingType": "string"
                 }
             ],
       "Code": "` + jsSanitizeString(zygoZomeCode) + `"
@@ -1431,7 +1434,7 @@ func TestingAppAppPackage() string {
                 },
                 {
                     "Name": "rating",
-                    "DataFormat": "links",
+                    "DataFormat": "links"
                 },
                 {
                     "Name": "review",
@@ -1440,7 +1443,7 @@ func TestingAppAppPackage() string {
                 },
                 {
                     "Name": "secret",
-                    "DataFormat": "string",
+                    "DataFormat": "string"
                 }
             ],
             "Functions": [
@@ -1490,37 +1493,44 @@ func TestingAppAppPackage() string {
         "Zome":   "zySampleZome",
         "FnName": "addEven",
         "Input":  "2",
-        "Output": "%h%"},
+        "Output": "%h%"
+    },
     {
         "Zome":   "zySampleZome",
         "FnName": "addEven",
         "Input":  "4",
-        "Output": "%h%"},
+        "Output": "%h%"
+    },
     {
         "Zome":   "zySampleZome",
         "FnName": "addEven",
         "Input":  "5",
-        "Err":    "Error calling 'commit': Validation Failed"},
+        "Err":    "Error calling 'commit': Validation Failed"
+    },
     {
         "Zome":   "zySampleZome",
         "FnName": "addPrime",
         "Input":  {"prime":7},
-        "Output": "%h%"},
+        "Output": "%h%"
+    },
     {
         "Zome":   "zySampleZome",
         "FnName": "addPrime",
         "Input":  {"prime":4},
-        "Err":    "Error calling 'commit': Validation Failed"},
+        "Err":    "Error calling 'commit': Validation Failed"
+    },
     {
 	"Zome":   "jsSampleZome",
 	"FnName": "addProfile",
 	"Input":  {"firstName":"Art","lastName":"Brock"},
-	"Output": "%h%"},
+	"Output": "%h%"
+    },
     {
 	"Zome":   "zySampleZome",
 	"FnName": "getDNA",
 	"Input":  "",
-	"Output": "%dna%"},
+	"Output": "%dna%"
+    },
     {
 	"Zome":     "zySampleZome",
 	"FnName":   "getDNA",
@@ -1544,22 +1554,26 @@ func TestingAppAppPackage() string {
 	"Zome":   "jsSampleZome",
 	"FnName": "addOdd",
 	"Input":  "7",
-	"Output": "%h%"},
+	"Output": "%h%"
+    },
     {
 	"Zome":   "jsSampleZome",
 	"FnName": "addOdd",
 	"Input":  "2",
-	"Err":    "Validation Failed"},
+	"Err":    "Validation Failed"
+    },
     {
 	"Zome":   "zySampleZome",
 	"FnName": "confirmOdd",
 	"Input":  "9",
-	"Output": "false"},
+	"Output": "false"
+    },
     {
 	"Zome":   "zySampleZome",
 	"FnName": "confirmOdd",
 	"Input":  "7",
-	"Output": "true"},
+	"Output": "true"
+    },
     {
 	"Zome":   "jsSampleZome",
 	"Input":  "unexposed(\"this is a\")",
@@ -1571,7 +1585,7 @@ func TestingAppAppPackage() string {
 	"Zome":   "jsSampleZome",
 	"FnName": "testJsonFn2",
 	"Input": "",
-	"Output": ["a":"b"]
+	"Output": [{"a":"b"}]
     },
     {
    	"Convey": "agent fixture substitution works",

--- a/service_test.go
+++ b/service_test.go
@@ -373,7 +373,7 @@ func TestSaveFromAppPackage(t *testing.T) {
 	Convey("it should write out a appPackage file to a directory tree with JSON encoding", t, func() {
 		appPackageReader := bytes.NewBuffer([]byte(BasicTemplateAppPackage))
 
-		appPackage, err := s.SaveFromAppPackage(appPackageReader, root, "appName", nil, "json", false)
+		appPackage, err := s.SaveFromAppPackage(appPackageReader, root, "appName", nil, BasicTemplateAppPackageFormat, "json", false)
 		So(err, ShouldBeNil)
 		So(appPackage, ShouldNotBeNil)
 		So(appPackage.Version, ShouldEqual, AppPackageVersion)
@@ -404,7 +404,7 @@ func TestSaveFromAppPackage(t *testing.T) {
 
 		root2 := filepath.Join(s.Path, name+"2")
 
-		appPackage, err := s.SaveFromAppPackage(appPackageReader, root2, "appName", nil, "toml", false)
+		appPackage, err := s.SaveFromAppPackage(appPackageReader, root2, "appName", nil, BasicTemplateAppPackageFormat, "toml", false)
 		So(err, ShouldBeNil)
 		So(appPackage, ShouldNotBeNil)
 		So(appPackage.Version, ShouldEqual, AppPackageVersion)
@@ -416,7 +416,7 @@ func TestSaveFromAppPackage(t *testing.T) {
 	Convey("it should write out a appPackage file to a directory tree with binary UI files", t, func() {
 		appPackageReader := bytes.NewBuffer([]byte(TestingAppAppPackage()))
 
-		_, err := s.SaveFromAppPackage(appPackageReader, root+"3", "appName2", nil, "json", false)
+		_, err := s.SaveFromAppPackage(appPackageReader, root+"3", "appName2", nil, TestingAppDecodingFormat, "json", false)
 		root3 := filepath.Join(s.Path, name+"3")
 
 		So(err, ShouldBeNil)
@@ -475,7 +475,7 @@ func TestMakeAppPackage(t *testing.T) {
 			panic(err)
 		}
 		root = filepath.Join(s.Path, "appFromAppPackage")
-		appPackage, err := s.SaveFromAppPackage(appPackageReader, root, "appFromAppPackage", nil, "json", false)
+		appPackage, err := s.SaveFromAppPackage(appPackageReader, root, "appFromAppPackage", nil, "json", "json", false)
 		So(err, ShouldBeNil)
 		So(appPackage, ShouldNotBeNil)
 		So(appPackage.Version, ShouldEqual, AppPackageVersion)

--- a/service_test.go
+++ b/service_test.go
@@ -518,6 +518,7 @@ func TestLoadTestFiles(t *testing.T) {
 		tests, err := LoadTestFiles(path)
 		So(err, ShouldBeNil)
 		So(len(tests), ShouldEqual, 2)
+		So(tests["testSet1"].Identity, ShouldEqual, "123-456-7890")
 	})
 }
 


### PR DESCRIPTION
Test files were an array of TestData.  Now are an object like this: 

```
TestSet{TestData:[...],Identity:"string for agent identity",Fixtures{Agents:[Hash:"Qm...",Identity:"..."]...]}
```