### PR TITLE
fixed bugs that caused 'too many open files' err in bs, closes #508

### DIFF
--- a/bs.go
+++ b/bs.go
@@ -49,7 +49,12 @@ func (h *Holochain) BSpost() (err error) {
 	b, err = json.Marshal(req)
 	//var resp *http.Response
 	if err == nil {
-		_, err = http.Post(url, "application/json", bytes.NewBuffer(b))
+		var resp *http.Response
+		resp, err = http.Post(url, "application/json", bytes.NewBuffer(b))
+		if err == nil {
+			resp.Body.Close()
+		}
+
 	}
 	return
 }
@@ -97,10 +102,20 @@ func (h *Holochain) BSget() (err error) {
 	}
 	id := h.DNAHash()
 	url := fmt.Sprintf("http://%s/%s", host, id.String())
+
+	var req *http.Request
+
+	req, err = http.NewRequest("GET", url, nil)
+	if err != nil {
+		return
+	}
+	req.Close = true
+	client := http.DefaultClient
 	var resp *http.Response
-	resp, err = http.Get(url)
+	resp, err = client.Do(req)
+
+	//	resp, err = http.Get(url)
 	if err == nil {
-		defer resp.Body.Close()
 		var b []byte
 		b, err = ioutil.ReadAll(resp.Body)
 		if err == nil {
@@ -111,6 +126,8 @@ func (h *Holochain) BSget() (err error) {
 
 			}
 		}
+		resp.Body.Close()
+
 	}
 	return
 }

--- a/cmd/bs/bs.go
+++ b/cmd/bs/bs.go
@@ -210,10 +210,21 @@ func getCompleteConnectionList(response http.ResponseWriter, request *http.Reque
 }
 
 func serve(port int) (err error) {
-	http.HandleFunc("/", h)
-	http.HandleFunc("/getCompleteConnectionList", getCompleteConnectionList)
+
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/", h)
+	mux.HandleFunc("/getCompleteConnectionList", getCompleteConnectionList)
 
 	log.Infof("starting up on port %d", port)
-	err = http.ListenAndServe(fmt.Sprintf(":%d", port), nil) // set listen port
+
+	s := &http.Server{
+		Addr:           fmt.Sprintf(":%d", port), // set listen port
+		Handler:        mux,
+		ReadTimeout:    10 * time.Second,
+		WriteTimeout:   10 * time.Second,
+		MaxHeaderBytes: 1 << 20,
+	}
+	err = s.ListenAndServe()
 	return
 }


### PR DESCRIPTION
turns out that keep-alive was preventing resources from being cleaned up, both on client and server ends, and bootstrap server would die with 'too many files open' error. This commit fixes it on both ends, the client closes things, and the server times out if the client doesn't