### PR TITLE
added -fromDevelop and -fromBranch flags to hcdev, closes #514

### DIFF
--- a/cmd/hcdev/hcdev.go
+++ b/cmd/hcdev/hcdev.go
@@ -180,8 +180,8 @@ func setupApp() (app *cli.App) {
 		},
 	}
 
-	var interactive, dumpChain, dumpDHT, initTest bool
-	var clonePath, appPackagePath, cloneExample, outputDir string
+	var interactive, dumpChain, dumpDHT, initTest, fromDevelop bool
+	var clonePath, appPackagePath, cloneExample, outputDir, fromBranch string
 	app.Commands = []cli.Command{
 		{
 			Name:    "init",
@@ -212,6 +212,16 @@ func setupApp() (app *cli.App) {
 					Name:        "cloneExample",
 					Usage:       "example from github.com/holochain to clone from",
 					Destination: &cloneExample,
+				},
+				cli.StringFlag{
+					Name:        "fromBranch",
+					Usage:       "specify a specify branch name whith cloneExample",
+					Destination: &fromBranch,
+				},
+				cli.BoolFlag{
+					Name:        "fromDevelop",
+					Usage:       "specify that cloneExample should use the 'develop' branch",
+					Destination: &fromDevelop,
 				},
 			},
 			ArgsUsage: "<name>",
@@ -293,12 +303,29 @@ func setupApp() (app *cli.App) {
 					if err != nil {
 						return cmd.MakeErrFromErr(c, err)
 					}
+					if fromDevelop {
+						fromBranch = "develop"
+					}
 					command := exec.Command("git", "clone", fmt.Sprintf("git://github.com/Holochain/%s.git", cloneExample))
 					out, err := command.CombinedOutput()
 					fmt.Printf("git: %s\n", string(out))
 					if err != nil {
 						return cmd.MakeErrFromErr(c, err)
 					}
+
+					if fromBranch != "" {
+						err = os.Chdir(filepath.Join(tmpCopyDir, cloneExample))
+						if err != nil {
+							return cmd.MakeErrFromErr(c, err)
+						}
+						command := exec.Command("git", "checkout", fromBranch)
+						out, err := command.CombinedOutput()
+						fmt.Printf("git: %s\n", string(out))
+						if err != nil {
+							return cmd.MakeErrFromErr(c, err)
+						}
+					}
+
 					clonePath := filepath.Join(tmpCopyDir, cloneExample)
 					fmt.Printf("cloning %s from github.com/Holochain/%s\n", name, cloneExample)
 					err = doClone(service, clonePath, devPath)

--- a/cmd/hcdev/hcdev.go
+++ b/cmd/hcdev/hcdev.go
@@ -215,7 +215,7 @@ func setupApp() (app *cli.App) {
 				},
 				cli.StringFlag{
 					Name:        "fromBranch",
-					Usage:       "specify a specify branch name whith cloneExample",
+					Usage:       "specify branch to use with cloneExample",
 					Destination: &fromBranch,
 				},
 				cli.BoolFlag{

--- a/cmd/hcdev/hcdev_test.go
+++ b/cmd/hcdev/hcdev_test.go
@@ -135,6 +135,15 @@ func TestInit(t *testing.T) {
 		err = app.Run(os.Args)
 		So(err, ShouldBeNil)
 		So(cmd.IsFile(filepath.Join(tmpTestDir, "clutter", "dna", "clutter", "clutter.js")), ShouldBeTrue)
+		// or from a branch
+		err = os.Chdir(tmpTestDir)
+		if err != nil {
+			panic(err)
+		}
+		os.Args = []string{"hcdev", "init", "-cloneExample=clutter", "-fromDevelop", "clutter2"}
+		err = app.Run(os.Args)
+		So(err, ShouldBeNil)
+		So(cmd.IsFile(filepath.Join(tmpTestDir, "clutter2", "dna", "clutter", "clutter.js")), ShouldBeTrue)
 
 		// or with a specified name
 		err = os.Chdir(tmpTestDir)


### PR DESCRIPTION
this makes it work to do cloneExample when the develop branch moves ahead of master in some way that breaks the apps on master (as is currently the case with clutter).