### PR TITLE
Makefile fix 512

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,13 @@ $(error GOPATH *must* be defined)
 endif
 
 GOBIN = $(value GOPATH)/bin
+
+ifeq ($(OS),Windows_NT)
+$(warning using hardcoded repo of github.com/metacurrency/holochain)
+REPO = github.com/metacurrency/holochain
+else
 REPO = $(CURDIR:$(GOPATH)/src/%=%)
+endif
 # Remove a $(GOPATH)/src/ from the beginning of the current directory.
 # Likely to be github.com/metacurrency/holochain
 


### PR DESCRIPTION
Fixes #512 by hardcoding the path if the user is on windows. Make isn't great for doing platform independent things so this is the best I could come up with. I request someone on windows tests this before we merge.