### PR TITLE
feature benchmarking, closes #511

### DIFF
--- a/apptest/apptest.go
+++ b/apptest/apptest.go
@@ -151,6 +151,9 @@ func TestScenario(h *Holochain, scenario string, role string, replacementPairs m
 	if err != nil {
 		return
 	}
+	if testSet.Identity != "" {
+		SetIdentity(h, AgentIdentity(testSet.Identity))
+	}
 
 	err = initChainForTest(h, true)
 	if err != nil {
@@ -612,12 +615,12 @@ func test(h *Holochain, one string, bridgeApps []BridgeApp, benchmarks bool) []e
 		info.Logf("Test: '%s' starting...", name)
 		info.Log("========================================")
 		// setup the genesis entries
+		identity := defaultIdentity
 		if ts.Identity != "" {
-			id := AgentIdentity(ts.Identity)
-			h.Agent().SetIdentity(id)
-		} else {
-			h.Agent().SetIdentity(defaultIdentity)
+			identity = AgentIdentity(ts.Identity)
 		}
+		SetIdentity(h, identity)
+		h.Debugf("Setting identity to:%v", h.Agent().Identity())
 		err = initChainForTest(h, true)
 		var ers []error
 		if err != nil {

--- a/apptest/apptest.go
+++ b/apptest/apptest.go
@@ -82,8 +82,14 @@ func testStringReplacements(input string, r *replacements) string {
 					panic(err)
 				}
 			}
-			hash := h.Chain().Nth(hashIdx).EntryLink
-			output = strings.Replace(output, m[1], hash.String(), -1)
+			entry := h.Chain().Nth(hashIdx)
+			var hash string
+			if entry != nil {
+				hash = entry.EntryLink.String()
+			} else {
+				hash = fmt.Sprintf("<%d: entry doesn't exist>", hashIdx)
+			}
+			output = strings.Replace(output, m[1], hash, -1)
 		}
 	}
 
@@ -453,6 +459,8 @@ func DoTest(h *Holochain, name string, i int, fixtures TestFixtures, t TestData,
 		if t.Wait > 0 {
 			info.Logf("   waiting %dms...", t.Wait)
 			time.Sleep(time.Millisecond * t.Wait)
+			elapsed := time.Now().Sub(startTime) / time.Millisecond
+			info.Logf("   test '%s.%d%s' continuing at t+%dms", name, i, rStr, elapsed)
 		}
 
 		h.Debugf("Input before replacement: %s", input)

--- a/apptest/apptest_test.go
+++ b/apptest/apptest_test.go
@@ -2,10 +2,12 @@ package apptest
 
 import (
 	. "github.com/metacurrency/holochain"
+	. "github.com/metacurrency/holochain/hash"
 	. "github.com/smartystreets/goconvey/convey"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestMain(m *testing.M) {
@@ -73,7 +75,7 @@ func TestTest(t *testing.T) {
 		h.Config.Loggers.TestInfo.Enabled = false
 	}
 	Convey("it should fail if there's no test data", t, func() {
-		err := Test(h, nil)
+		err := Test(h, nil, false)
 		So(err[0].Error(), ShouldEqual, "open "+h.TestPath()+": no such file or directory")
 	})
 	CleanupTestDir(d)
@@ -89,11 +91,11 @@ func TestTest(t *testing.T) {
 		h.Config.Loggers.TestInfo.Enabled = false
 	}
 	Convey("it should validate on test data", t, func() {
-		err := Test(h, nil)
+		err := Test(h, nil, false)
 		So(err, ShouldBeNil)
 	})
 	Convey("it should reset the database state and thus run correctly twice", t, func() {
-		err := Test(h, nil)
+		err := Test(h, nil, false)
 		So(err, ShouldBeNil)
 	})
 
@@ -101,19 +103,19 @@ func TestTest(t *testing.T) {
 		os.Remove(filepath.Join(d, ".holochain", "test", "test", "test_0.json"))
 		err := WriteFile([]byte(`{"Tests":[{"Zome":"zySampleZome","FnName":"addEven","Input":"2","Output":"","Err":"bogus error"}]}`), d, ".holochain", "test", "test", "test_0.json")
 		So(err, ShouldBeNil)
-		err = Test(h, nil)[0]
+		err = Test(h, nil, false)[0]
 		So(err, ShouldNotBeNil)
 		//So(err.Error(), ShouldEqual, "Test: test_0:0\n  Expected Error: bogus error\n  Got: nil\n")
 		So(err.Error(), ShouldEqual, "bogus error")
 	})
 	Convey("it should fail the tests on code with zygo syntax errors", t, func() {
 		h.Nucleus().DNA().Zomes[0].Code += "badcode)("
-		errs := Test(h, nil)
+		errs := Test(h, nil, false)
 		So(len(errs), ShouldEqual, 12)
 	})
 	Convey("it should fail the tests on code with js syntax errors", t, func() {
 		h.Nucleus().DNA().Zomes[1].Code += "badcode)("
-		errs := Test(h, nil)
+		errs := Test(h, nil, false)
 		So(len(errs), ShouldEqual, 3)
 	})
 }
@@ -131,7 +133,7 @@ func TestTestOne(t *testing.T) {
 	Convey("it should validate on test data", t, func() {
 
 		ShouldLog(&h.Config.Loggers.TestInfo, func() {
-			err := TestOne(h, "testSet1", nil)
+			err := TestOne(h, "testSet1", nil, false)
 			So(err, ShouldBeNil)
 		}, `========================================
 Test: 'testSet1' starting...
@@ -154,9 +156,76 @@ func TestTestScenario(t *testing.T) {
 	Convey("it should run a test scenario", t, func() {
 		// the sample scenario is supposed to fail
 		ShouldLog(&h.Config.Loggers.TestFailed, func() {
-			err, errs := TestScenario(h, "sampleScenario", "speaker", map[string]string{"%server%": "server_foo"})
+			err, errs := TestScenario(h, "sampleScenario", "speaker", map[string]string{"%server%": "server_foo"}, false)
 			So(err, ShouldBeNil)
 			So(len(errs), ShouldEqual, 1)
 		}, `server_foo`)
 	})
+}
+
+func TestTestBenchmark(t *testing.T) {
+	d, _, h := PrepareTestChain("test")
+	defer CleanupTestChain(h, d)
+
+	Convey("it should calculate benchmark data", t, func() {
+		benchmark := StartBench(h)
+		time.Sleep(time.Millisecond)
+		benchmark.End()
+		So(benchmark.ElapsedTime, ShouldBeGreaterThanOrEqualTo, time.Millisecond)
+		So(benchmark.ChainGrowth, ShouldEqual, 0)
+		So(benchmark.DHTGrowth, ShouldEqual, 0)
+
+		benchmark = StartBench(h)
+		commit(h, "oddNumbers", "7")
+		benchmark.End()
+		So(benchmark.ChainGrowth, ShouldBeGreaterThan, 0)
+		So(benchmark.DHTGrowth, ShouldBeGreaterThan, 0)
+		So(benchmark.CPU, ShouldBeGreaterThan, 0)
+	})
+}
+
+func TestTestBenchmarks(t *testing.T) {
+
+	d, _, h := SetupTestChain("test")
+	defer CleanupTestChain(h, d)
+
+	_, requested := DebuggingRequestedViaEnv()
+	if !requested {
+		h.Config.Loggers.TestPassed.Enabled = false
+		h.Config.Loggers.TestFailed.Enabled = false
+		h.Config.Loggers.TestInfo.Enabled = false
+	}
+
+	Convey("test should output benchmark info", t, func() {
+		ShouldLog(&h.Config.Loggers.TestInfo, func() {
+			err := test(h, "testSet1", nil, true)
+			So(err, ShouldBeNil)
+		},
+			`Benchmark for testSet1:8:`,
+			`Elapsed time:`,
+			`Chain growth:`,
+			`DHT growth:`,
+			`Benchmark Summary:`,
+			`Total elapsed time:`,
+			`Total chain growth:`,
+			`Total DHT growth:`,
+			`Total CPU use:`,
+		)
+	})
+}
+
+func commit(h *Holochain, entryType, entryStr string) (entryHash Hash) {
+	entry := GobEntry{C: entryStr}
+
+	r, err := NewCommitAction(entryType, &entry).Do(h)
+	if err != nil {
+		panic(err)
+	}
+	if r != nil {
+		entryHash = r.(Hash)
+	}
+	if err != nil {
+		panic(err)
+	}
+	return
 }

--- a/apptest/apptest_test.go
+++ b/apptest/apptest_test.go
@@ -186,12 +186,14 @@ func TestTestBenchmark(t *testing.T) {
 		So(benchmark.CPU, ShouldBeGreaterThanOrEqualTo, 0)
 	})
 
-	Convey("it should calculate file size growth benchmark data", t, func() {
+	Convey("it should calculate data sent growth benchmark data", t, func() {
 		benchmark := StartBench(h)
-		BytesSentChan <- int64(100)
-		BytesSentChan <- int64(200)
+		BytesSentChan <- BytesSent{Bytes: int64(100), MsgType: PUT_REQUEST}
+		BytesSentChan <- BytesSent{Bytes: int64(500), MsgType: GOSSIP_REQUEST}
+		BytesSentChan <- BytesSent{Bytes: int64(200), MsgType: GET_REQUEST}
 		benchmark.End()
 		So(benchmark.BytesSent, ShouldEqual, 300)
+		So(benchmark.GossipSent, ShouldEqual, 500)
 	})
 }
 

--- a/apptest/apptest_test.go
+++ b/apptest/apptest_test.go
@@ -167,20 +167,31 @@ func TestTestBenchmark(t *testing.T) {
 	d, _, h := PrepareTestChain("test")
 	defer CleanupTestChain(h, d)
 
-	Convey("it should calculate benchmark data", t, func() {
+	Convey("it should calculate time passed benchmark data", t, func() {
 		benchmark := StartBench(h)
 		time.Sleep(time.Millisecond)
 		benchmark.End()
 		So(benchmark.ElapsedTime, ShouldBeGreaterThanOrEqualTo, time.Millisecond)
 		So(benchmark.ChainGrowth, ShouldEqual, 0)
 		So(benchmark.DHTGrowth, ShouldEqual, 0)
+		So(benchmark.BytesSent, ShouldEqual, 0)
+	})
 
-		benchmark = StartBench(h)
+	Convey("it should calculate file size growth benchmark data", t, func() {
+		benchmark := StartBench(h)
 		commit(h, "oddNumbers", "7")
 		benchmark.End()
 		So(benchmark.ChainGrowth, ShouldBeGreaterThan, 0)
 		So(benchmark.DHTGrowth, ShouldBeGreaterThan, 0)
 		So(benchmark.CPU, ShouldBeGreaterThan, 0)
+	})
+
+	Convey("it should calculate file size growth benchmark data", t, func() {
+		benchmark := StartBench(h)
+		BytesSentChan <- int64(100)
+		BytesSentChan <- int64(200)
+		benchmark.End()
+		So(benchmark.BytesSent, ShouldEqual, 300)
 	})
 }
 
@@ -205,11 +216,13 @@ func TestTestBenchmarks(t *testing.T) {
 			`Elapsed time:`,
 			`Chain growth:`,
 			`DHT growth:`,
+			`Bytes sent:`,
 			`Benchmark Summary:`,
 			`Total elapsed time:`,
 			`Total chain growth:`,
 			`Total DHT growth:`,
 			`Total CPU use:`,
+			`Total Bytes sent:`,
 		)
 	})
 }

--- a/apptest/apptest_test.go
+++ b/apptest/apptest_test.go
@@ -130,14 +130,14 @@ func TestTestOne(t *testing.T) {
 	}
 	Convey("it should validate on test data", t, func() {
 
-		ShouldLog(&h.Config.Loggers.TestInfo, `========================================
+		ShouldLog(&h.Config.Loggers.TestInfo, func() {
+			err := TestOne(h, "testSet1", nil)
+			So(err, ShouldBeNil)
+		}, `========================================
 Test: 'testSet1' starting...
 ========================================
 Test 'testSet1.0' t+0ms: { zySampleZome addEven 2 %h%   0s 0s  false 0}
-`, func() {
-			err := TestOne(h, "testSet1", nil)
-			So(err, ShouldBeNil)
-		})
+`)
 	})
 }
 
@@ -153,10 +153,10 @@ func TestTestScenario(t *testing.T) {
 	}
 	Convey("it should run a test scenario", t, func() {
 		// the sample scenario is supposed to fail
-		ShouldLog(&h.Config.Loggers.TestFailed, `server_foo`, func() {
+		ShouldLog(&h.Config.Loggers.TestFailed, func() {
 			err, errs := TestScenario(h, "sampleScenario", "speaker", map[string]string{"%server%": "server_foo"})
 			So(err, ShouldBeNil)
 			So(len(errs), ShouldEqual, 1)
-		})
+		}, `server_foo`)
 	})
 }

--- a/apptest/apptest_test.go
+++ b/apptest/apptest_test.go
@@ -138,7 +138,7 @@ func TestTestOne(t *testing.T) {
 		}, `========================================
 Test: 'testSet1' starting...
 ========================================
-Test 'testSet1.0' t+0ms: { zySampleZome addEven 2 %h%   0s 0s  false 0}
+Test 'testSet1.0' t+0ms: { zySampleZome addEven 2 %h%   0s 0s  false 0 false}
 `)
 	})
 }

--- a/apptest/apptest_test.go
+++ b/apptest/apptest_test.go
@@ -183,7 +183,7 @@ func TestTestBenchmark(t *testing.T) {
 		benchmark.End()
 		So(benchmark.ChainGrowth, ShouldBeGreaterThan, 0)
 		So(benchmark.DHTGrowth, ShouldBeGreaterThan, 0)
-		So(benchmark.CPU, ShouldBeGreaterThan, 0)
+		So(benchmark.CPU, ShouldBeGreaterThanOrEqualTo, 0)
 	})
 
 	Convey("it should calculate file size growth benchmark data", t, func() {

--- a/bridge_test.go
+++ b/bridge_test.go
@@ -21,10 +21,10 @@ func TestBridgeCall(t *testing.T) {
 
 	fakeFromApp, _ := NewHash("QmVGtdTZdTFaLsaj2RwdVG8jcjNNcp1DE914DKZ2kHmXHx")
 	Convey("it should call the bridgeGenesis function when bridging on the to side", t, func() {
-		ShouldLog(h.nucleus.alog, `bridge genesis to-- other side is:`+fakeFromApp.String()+` bridging data:app data`, func() {
+		ShouldLog(h.nucleus.alog, func() {
 			token, err = h.AddBridgeAsCallee(fakeFromApp, "app data")
 			So(err, ShouldBeNil)
-		})
+		}, `bridge genesis to-- other side is:`+fakeFromApp.String()+` bridging data:app data`)
 		c := Capability{Token: token, db: h.bridgeDB}
 		bridgeSpecStr, err := c.Validate(nil)
 		So(err, ShouldBeNil)
@@ -35,11 +35,11 @@ func TestBridgeCall(t *testing.T) {
 	Convey("it should call the bridgeGenesis function when bridging on the from side", t, func() {
 		h.nucleus.dna.Zomes[0].BridgeTo = fakeToApp
 		h.nucleus.dna.Zomes[0].BridgeTo = fakeToApp
-		ShouldLog(h.nucleus.alog, `bridge genesis from-- other side is:`+fakeToApp.String()+` bridging data:app data`, func() {
+		ShouldLog(h.nucleus.alog, func() {
 			url := "http://localhost:31415"
 			err := h.AddBridgeAsCaller(fakeToApp, token, url, "app data")
 			So(err, ShouldBeNil)
-		})
+		}, `bridge genesis from-- other side is:`+fakeToApp.String()+` bridging data:app data`)
 	})
 
 	Convey("it should call the bridged function", t, func() {

--- a/change_test.go
+++ b/change_test.go
@@ -9,16 +9,16 @@ import (
 func TestChange(t *testing.T) {
 	Convey("it should be able to log deprecation messages", t, func() {
 		c := Change{Type: Deprecation, Message: "deprecated as of %d", AsOf: 2}
-		ShouldLog(&infoLog, "Deprecation warning: deprecated as of 2\n", func() {
+		ShouldLog(&infoLog, func() {
 			c.Log()
-		})
+		}, "Deprecation warning: deprecated as of 2\n")
 
 	})
 
 	Convey("it should be able to log requirement messages", t, func() {
 		c := Change{Type: Warning, Message: "required as of %d", AsOf: 2}
-		ShouldLog(&infoLog, "Warning: required as of 2\n", func() {
+		ShouldLog(&infoLog, func() {
 			c.Log()
-		})
+		}, "Warning: required as of 2\n")
 	})
 }

--- a/cmd/hcdev/hcdev.go
+++ b/cmd/hcdev/hcdev.go
@@ -440,30 +440,14 @@ func setupApp() (app *cli.App) {
 					if len(x) > 0 {
 						clone = x[1]
 						pairs["%clone%"] = clone
-					} else {
-
-						// if there isn't a clone then we can do role substitutions
-						var roles []string
-						roles, err = holo.GetTestScenarioRoles(h, scenario)
-						if err != nil {
-							return cmd.MakeErrFromErr(c, err)
-						}
-						host := getHostName(serverID)
-						for _, role := range roles {
-							var id, hash string
-							id = role + "@" + host
-							agent, err := holo.NewAgent(holo.LibP2P, holo.AgentIdentity(id), holo.MakeTestSeed(id))
-							if err != nil {
-								return cmd.MakeErrFromErr(c, err)
-							}
-							_, hash, err = agent.NodeID()
-							if err != nil {
-								return cmd.MakeErrFromErr(c, err)
-							}
-							pairs["%"+role+"_str%"] = id
-							pairs["%"+role+"_key%"] = hash
-						}
 					}
+
+					host := getHostName(serverID)
+					err = addRolesToPairs(h, scenario, host, pairs)
+					if err != nil {
+						return cmd.MakeErrFromErr(c, err)
+					}
+
 					err, errs = TestScenario(h, scenario, role, pairs, benchmarks)
 					if err != nil {
 						return cmd.MakeErrFromErr(c, err)
@@ -632,11 +616,10 @@ func setupApp() (app *cli.App) {
 							"-serverID="+serverID,
 							"-agentID="+agentID,
 
-							fmt.Sprintf("-benchmarks=%v", benchmarks),
-
 							fmt.Sprintf("-bootstrapServer=%v", bootstrapServer),
 							fmt.Sprintf("-keepalive=%v", keepalive),
 							"test",
+							fmt.Sprintf("-benchmarks=%v", benchmarks),
 							fmt.Sprintf("-syncPauseUntil=%v", secondsFromNowPlusDelay),
 							scenarioName,
 							originalRoleName,
@@ -959,8 +942,7 @@ func getHolochain(c *cli.Context, service *holo.Service, identity string) (h *ho
 	}
 
 	if identity != "" {
-		agent.SetIdentity(holo.AgentIdentity(identity))
-		agent.GenKeys(holo.MakeTestSeed(identity))
+		holo.SetAgentIdentity(agent, holo.AgentIdentity(identity))
 	}
 
 	bridgeApps = make([]holo.BridgeApp, 0)
@@ -1118,5 +1100,71 @@ func getIdentity(agentID, serverID string) (identity string) {
 	}
 
 	identity = username + "@" + host
+	return
+}
+
+func addRolesToPairs(h *holo.Holochain, scenario string, host string, pairs map[string]string) (err error) {
+
+	var roles []string
+	roles, err = holo.GetTestScenarioRoles(h, scenario)
+	if err != nil {
+		return
+	}
+
+	dir := filepath.Join(h.TestPath(), scenario)
+	var config *holo.TestConfig
+	config, err = holo.LoadTestConfig(dir)
+	if err != nil {
+		return
+	}
+
+	cloneRoles := make(map[string]holo.CloneSpec)
+	for _, spec := range config.Clone {
+		cloneRoles[spec.Role] = spec
+	}
+
+	for _, role := range roles {
+
+		var testSet holo.TestSet
+		testSet, err = holo.LoadTestFile(dir, role+".json")
+		if err != nil {
+			return
+		}
+		spec, isClone := cloneRoles[role]
+
+		if testSet.Identity != "" {
+			if isClone {
+				err = fmt.Errorf("can't both clone and specify an identity: role %s", role)
+				return
+			}
+			err = addRoleToPairs(h, role, testSet.Identity, pairs)
+		} else {
+			if isClone {
+				origRole := role
+				for i := 0; i < spec.Number; i++ {
+					role = fmt.Sprintf("%s.%d", origRole, i)
+					err = addRoleToPairs(h, role, fmt.Sprintf("%s@%s", role, host), pairs)
+				}
+			} else {
+				err = addRoleToPairs(h, role, role+"@"+host, pairs)
+			}
+		}
+
+	}
+	return
+}
+func addRoleToPairs(h *holo.Holochain, role string, id string, pairs map[string]string) (err error) {
+	var agent holo.Agent
+	agent, err = holo.NewAgent(holo.LibP2P, holo.AgentIdentity(id), holo.MakeTestSeed(id))
+	if err != nil {
+		return
+	}
+	var hash string
+	_, hash, err = agent.NodeID()
+	if err != nil {
+		return
+	}
+	pairs["%"+role+"_str%"] = id
+	pairs["%"+role+"_key%"] = hash
 	return
 }

--- a/cmd/hcdev/hcdev.go
+++ b/cmd/hcdev/hcdev.go
@@ -180,7 +180,7 @@ func setupApp() (app *cli.App) {
 		},
 	}
 
-	var interactive, dumpChain, dumpDHT, initTest bool
+	var interactive, dumpChain, dumpDHT, initTest, benchmarks bool
 	var clonePath, appPackagePath, cloneExample, outputDir string
 	app.Commands = []cli.Command{
 		{
@@ -361,6 +361,11 @@ func setupApp() (app *cli.App) {
 					Usage:       "unix timestamp - sync tests to run at this time",
 					Destination: &syncPauseUntil,
 				},
+				cli.BoolFlag{
+					Name:        "benchmarks",
+					Usage:       "calculate benchmarks during test",
+					Destination: &benchmarks,
+				},
 			},
 			Action: func(c *cli.Context) error {
 				holo.Debug("test: start")
@@ -431,16 +436,16 @@ func setupApp() (app *cli.App) {
 							pairs["%"+role+"_key%"] = hash
 						}
 					}
-					err, errs = TestScenario(h, scenario, role, pairs)
+					err, errs = TestScenario(h, scenario, role, pairs, benchmarks)
 					if err != nil {
 						return cmd.MakeErrFromErr(c, err)
 					}
 					//holo.Debugf("testScenario: h: %v\n", spew.Sdump(h))
 
 				} else if len(args) == 1 {
-					errs = TestOne(h, args[0], bridgeApps)
+					errs = TestOne(h, args[0], bridgeApps, benchmarks)
 				} else if len(args) == 0 {
-					errs = Test(h, bridgeApps)
+					errs = Test(h, bridgeApps, benchmarks)
 				} else {
 					return cmd.MakeErr(c, "expected 0 args (run all stand-alone tests), 1 arg (a single stand-alone test) or 2 args (scenario and role)")
 				}
@@ -465,6 +470,11 @@ func setupApp() (app *cli.App) {
 					Name:        "outputDir",
 					Usage:       "directory to send output",
 					Destination: &outputDir,
+				},
+				cli.BoolFlag{
+					Name:        "benchmarks",
+					Usage:       "calculate benchmarks during scenario test",
+					Destination: &benchmarks,
 				},
 			},
 			Action: func(c *cli.Context) error {
@@ -593,6 +603,9 @@ func setupApp() (app *cli.App) {
 							"-logPrefix="+logPrefix,
 							"-serverID="+serverID,
 							"-agentID="+agentID,
+
+							fmt.Sprintf("-benchmarks=%v", benchmarks),
+
 							fmt.Sprintf("-bootstrapServer=%v", bootstrapServer),
 							fmt.Sprintf("-keepalive=%v", keepalive),
 							"test",

--- a/gossip_test.go
+++ b/gossip_test.go
@@ -368,11 +368,11 @@ func TestGossipCycle(t *testing.T) {
 		log.color, log.f = log.setupColor("%{message}")
 
 		// if the code were rentrant the log would should the events in a different order
-		ShouldLog(log, "node0_starting gossipWith <peer.ID UfY4We>\nnode0_no new puts received\nnode0_finish gossipWith <peer.ID UfY4We>, err=<nil>\nnode0_starting gossipWith <peer.ID UfY4We>\nnode0_no new puts received\nnode0_finish gossipWith <peer.ID UfY4We>, err=<nil>\n", func() {
+		ShouldLog(log, func() {
 			go h0.dht.gossipWith(h1.nodeID)
 			h0.dht.gossipWith(h1.nodeID)
 			time.Sleep(time.Millisecond * 100)
-		})
+		}, "node0_starting gossipWith <peer.ID UfY4We>\nnode0_no new puts received\nnode0_finish gossipWith <peer.ID UfY4We>, err=<nil>\nnode0_starting gossipWith <peer.ID UfY4We>\nnode0_no new puts received\nnode0_finish gossipWith <peer.ID UfY4We>, err=<nil>\n")
 		log.color, log.f = log.setupColor(log.Format)
 	})
 }

--- a/holochain.go
+++ b/holochain.go
@@ -30,10 +30,10 @@ import (
 
 const (
 	// Version is the numeric version number of the holochain library
-	Version int = 18
+	Version int = 19
 
 	// VersionStr is the textual version number of the holochain library
-	VersionStr string = "18"
+	VersionStr string = "19"
 
 	// DefaultSendTimeout a time.Duration to wait by default for send to complete
 	DefaultSendTimeout = 3000 * time.Millisecond

--- a/jsribosome.go
+++ b/jsribosome.go
@@ -735,9 +735,10 @@ func NewJSRibosome(h *Holochain, zome *Zome) (n Ribosome, err error) {
 			return mkOttoErr(&jsr, err.Error())
 		}
 		if fn.CallingType == JSON_CALLING {
+			/* this is a mistake.
 			if !call.ArgumentList[2].IsObject() {
-				return mkOttoErr(&jsr, "function calling type requires object argument type")
-			}
+						return mkOttoErr(&jsr, "function calling type requires object argument type")
+					}*/
 		}
 		a.args = args[2].value.(string)
 

--- a/jsribosome_test.go
+++ b/jsribosome_test.go
@@ -138,10 +138,10 @@ func TestNewJSRibosome(t *testing.T) {
 			s, _ := z.lastResult.ToString()
 			So(s, ShouldEqual, "a bogus test holochain")
 
-			ShouldLog(&infoLog, "Warning: Getting special properties via property() is deprecated as of 3. Returning nil values.  Use App* instead\n", func() {
+			ShouldLog(&infoLog, func() {
 				_, err = z.Run(`property("` + ID_PROPERTY + `")`)
 				So(err, ShouldBeNil)
-			})
+			}, "Warning: Getting special properties via property() is deprecated as of 3. Returning nil values.  Use App* instead\n")
 
 		})
 
@@ -184,10 +184,10 @@ func TestNewJSRibosome(t *testing.T) {
 				panic(err)
 			}
 
-			ShouldLog(h.nucleus.alog, fmt.Sprintf(`[{"Side":0,"ToApp":"QmY8Mzg9F69e5P9AoQPYat655HEhc1TVGs11tmfNSzkqto"},{"Side":1,"Token":"%s"}]`, token), func() {
+			ShouldLog(h.nucleus.alog, func() {
 				_, err := z.Run(`testGetBridges()`)
 				So(err, ShouldBeNil)
-			})
+			}, fmt.Sprintf(`[{"Side":0,"ToApp":"QmY8Mzg9F69e5P9AoQPYat655HEhc1TVGs11tmfNSzkqto"},{"Side":1,"Token":"%s"}]`, token))
 
 		})
 
@@ -302,18 +302,18 @@ func TestNewJSRibosome(t *testing.T) {
 			*/
 		})
 		Convey("send", func() {
-			ShouldLog(h.nucleus.alog, `result was: "{\"pong\":\"foobar\"}"`, func() {
+			ShouldLog(h.nucleus.alog, func() {
 				_, err := z.Run(`debug("result was: "+JSON.stringify(send(App.Key.Hash,{ping:"foobar"})))`)
 				So(err, ShouldBeNil)
-			})
+			}, `result was: "{\"pong\":\"foobar\"}"`)
 		})
 		Convey("send async", func() {
-			ShouldLog(h.nucleus.alog, `async result of message with 123 was: {"pong":"foobar"}`, func() {
+			ShouldLog(h.nucleus.alog, func() {
 				_, err := z.Run(`send(App.Key.Hash,{ping:"foobar"},{Callback:{Function:"asyncPing",ID:"123"}})`)
 				So(err, ShouldBeNil)
 				err = <-h.asyncSends
 				So(err, ShouldBeNil)
-			})
+			}, `async result of message with 123 was: {"pong":"foobar"}`)
 		})
 		Convey("send async with 100ms timeout", func() {
 			_, err := z.Run(`send(App.Key.Hash,{block:true},{Callback:{Function:"asyncPing",ID:"123"},Timeout:100})`)
@@ -343,42 +343,42 @@ func TestJSQuery(t *testing.T) {
 		profileHash := commit(h, "profile", `{"firstName":"Zippy","lastName":"Pinhead"}`)
 		commit(h, "rating", fmt.Sprintf(`{"Links":[{"Base":"%s","Link":"%s","Tag":"4stars"}]}`, hash.String(), profileHash.String()))
 
-		ShouldLog(h.nucleus.alog, `[3,7]`, func() {
+		ShouldLog(h.nucleus.alog, func() {
 			_, err := z.Run(`debug(query({Constrain:{EntryTypes:["oddNumbers"]}}))`)
 			So(err, ShouldBeNil)
-		})
-		ShouldLog(h.nucleus.alog, `["QmSwMfay3iCynzBFeq9rPzTMTnnuQSMUSe84whjcC9JPAo","QmfMPAEdN1BB9imcz97NsaYYaWEN3baC5aSDXqJSiWt4e6"]`, func() {
+		}, `[3,7]`)
+		ShouldLog(h.nucleus.alog, func() {
 			_, err := z.Run(`debug(query({Return:{Hashes:true},Constrain:{EntryTypes:["oddNumbers"]}}))`)
 			So(err, ShouldBeNil)
-		})
-		ShouldLog(h.nucleus.alog, `[{"Entry":3,"Hash":"QmSwMfay3iCynzBFeq9rPzTMTnnuQSMUSe84whjcC9JPAo"},{"Entry":7,"Hash":"QmfMPAEdN1BB9imcz97NsaYYaWEN3baC5aSDXqJSiWt4e6"}]`, func() {
+		}, `["QmSwMfay3iCynzBFeq9rPzTMTnnuQSMUSe84whjcC9JPAo","QmfMPAEdN1BB9imcz97NsaYYaWEN3baC5aSDXqJSiWt4e6"]`)
+		ShouldLog(h.nucleus.alog, func() {
 			_, err := z.Run(`debug(query({Return:{Hashes:true,Entries:true},Constrain:{EntryTypes:["oddNumbers"]}}))`)
 			So(err, ShouldBeNil)
-		})
-		ShouldLog(h.nucleus.alog, `[{"Entry":3,"Header":{"EntryLink":"QmSwMfay3iCynzBFeq9rPzTMTnnuQSMUSe84whjcC9JPAo","HeaderLink":"Qm`, func() {
+		}, `[{"Entry":3,"Hash":"QmSwMfay3iCynzBFeq9rPzTMTnnuQSMUSe84whjcC9JPAo"},{"Entry":7,"Hash":"QmfMPAEdN1BB9imcz97NsaYYaWEN3baC5aSDXqJSiWt4e6"}]`)
+		ShouldLog(h.nucleus.alog, func() {
 			_, err := z.Run(`debug(query({Return:{Headers:true,Entries:true},Constrain:{EntryTypes:["oddNumbers"]}}))`)
 			So(err, ShouldBeNil)
-		})
-		ShouldLog(h.nucleus.alog, `["foo","bar"]`, func() {
+		}, `[{"Entry":3,"Header":{"EntryLink":"QmSwMfay3iCynzBFeq9rPzTMTnnuQSMUSe84whjcC9JPAo","HeaderLink":"Qm`)
+		ShouldLog(h.nucleus.alog, func() {
 			_, err := z.Run(`debug(query({Constrain:{EntryTypes:["secret"]}}))`)
 			So(err, ShouldBeNil)
-		})
-		ShouldLog(h.nucleus.alog, `[{"firstName":"Zippy","lastName":"Pinhead"}]`, func() {
+		}, `["foo","bar"]`)
+		ShouldLog(h.nucleus.alog, func() {
 			_, err := z.Run(`debug(query({Constrain:{EntryTypes:["profile"]}}))`)
 			So(err, ShouldBeNil)
-		})
-		ShouldLog(h.nucleus.alog, `[{"Identity":"Herbert \u003ch@bert.com\u003e","PublicKey":"CAESIHLUfxjdoEfk8byjsBR+FXxYpYrFTviSBf2BbC0boylT","Revocation":null}]`, func() {
+		}, `[{"firstName":"Zippy","lastName":"Pinhead"}]`)
+		ShouldLog(h.nucleus.alog, func() {
 			_, err := z.Run(`debug(query({Constrain:{EntryTypes:["%agent"]}}))`)
 			So(err, ShouldBeNil)
-		})
-		ShouldLog(h.nucleus.alog, `{"message":"data format not implemented: _DNA","name":"HolochainError"}`, func() {
+		}, `[{"Identity":"Herbert \u003ch@bert.com\u003e","PublicKey":"CAESIHLUfxjdoEfk8byjsBR+FXxYpYrFTviSBf2BbC0boylT","Revocation":null}]`)
+		ShouldLog(h.nucleus.alog, func() {
 			_, err := z.Run(`debug(query({Constrain:{EntryTypes:["%dna"]}}))`)
 			So(err, ShouldBeNil)
-		})
-		ShouldLog(h.nucleus.alog, `[{"Links":[{"Base":"QmSwMfay3iCynzBFeq9rPzTMTnnuQSMUSe84whjcC9JPAo","Link":"QmYeinX5vhuA91D3v24YbgyLofw9QAxY6PoATrBHnRwbtt","Tag":"4stars"}]}]`, func() {
+		}, `{"message":"data format not implemented: _DNA","name":"HolochainError"}`)
+		ShouldLog(h.nucleus.alog, func() {
 			_, err := z.Run(`debug(query({Constrain:{EntryTypes:["rating"]}}))`)
 			So(err, ShouldBeNil)
-		})
+		}, `[{"Links":[{"Base":"QmSwMfay3iCynzBFeq9rPzTMTnnuQSMUSe84whjcC9JPAo","Link":"QmYeinX5vhuA91D3v24YbgyLofw9QAxY6PoATrBHnRwbtt","Tag":"4stars"}]}]`)
 	})
 }
 
@@ -401,22 +401,22 @@ func TestJSBridgeGenesis(t *testing.T) {
 	d, _, h := PrepareTestChain("test")
 	defer CleanupTestChain(h, d)
 
-	fakeToApp, _ := NewHash("QmVGtdTZdTFaLsaj2RwdVG8jcjNNcp1DE914DKZ2kHmXHx")
+	fakeToApp, _ := NewHash("QmVGtdTZdTFaLsaj2134RwdVG8jcjNNcp1DE914DKZ2kHmXHx")
 	Convey("it should fail if the bridge genesis function returns false", t, func() {
 
-		ShouldLog(&h.Config.Loggers.App, h.dnaHash.String()+" test data", func() {
+		ShouldLog(&h.Config.Loggers.App, func() {
 			z, err := NewJSRibosome(h, &Zome{RibosomeType: JSRibosomeType, Code: `function bridgeGenesis(side,app,data) {debug(app+" "+data);if (side==HC.Bridge.From) {return false;} return true;}`})
 			So(err, ShouldBeNil)
 			err = z.BridgeGenesis(BridgeFrom, h.dnaHash, "test data")
 			So(err.Error(), ShouldEqual, "bridgeGenesis failed")
-		})
+		}, h.dnaHash.String()+" test data")
 	})
 	Convey("it should work if the genesis function returns true", t, func() {
-		ShouldLog(&h.Config.Loggers.App, fakeToApp.String()+" test data", func() {
+		ShouldLog(&h.Config.Loggers.App, func() {
 			z, _ := NewJSRibosome(h, &Zome{RibosomeType: JSRibosomeType, Code: `function bridgeGenesis(side,app,data) {debug(app+" "+data);if (side==HC.Bridge.From) {return false;} return true;}`})
 			err := z.BridgeGenesis(BridgeTo, fakeToApp, "test data")
 			So(err, ShouldBeNil)
-		})
+		}, fakeToApp.String()+" test data")
 	})
 }
 
@@ -475,17 +475,17 @@ func TestJSValidateCommit(t *testing.T) {
 		v, err := NewJSRibosome(h, &Zome{RibosomeType: JSRibosomeType, Code: `function validateCommit(name,entry,header,pkg,sources) {debug(name);debug(entry);debug(JSON.stringify(header));debug(JSON.stringify(sources));debug(JSON.stringify(pkg));return true};`})
 		So(err, ShouldBeNil)
 		d := EntryDef{Name: "evenNumbers", DataFormat: DataFormatString}
-		ShouldLog(&h.Config.Loggers.App, `evenNumbers
-foo
-{"EntryLink":"QmNiCwBNA8MWDADTFVq1BonUEJbS2SvjAoNkZZrhEwcuU2","Time":"1970-01-01T00:00:01Z","Type":"evenNumbers"}
-["fakehashvalue"]
-{}
-`, func() {
+		ShouldLog(&h.Config.Loggers.App, func() {
 			a := NewCommitAction("oddNumbers", &GobEntry{C: "foo"})
 			a.header = &hdr
 			err = v.ValidateAction(a, &d, nil, []string{"fakehashvalue"})
 			So(err, ShouldBeNil)
-		})
+		}, `evenNumbers
+foo
+{"EntryLink":"QmNiCwBNA8MWDADTFVq1BonUEJbS2SvjAoNkZZrhEwcuU2","Time":"1970-01-01T00:00:01Z","Type":"evenNumbers"}
+["fakehashvalue"]
+{}
+`)
 	})
 	Convey("should run an entry value against the defined validator for string data", t, func() {
 		v, err := NewJSRibosome(h, &Zome{RibosomeType: JSRibosomeType, Code: `function validateCommit(name,entry,header,pkg,sources) { return (entry=="fish")};`})
@@ -660,14 +660,14 @@ func TestJSDHT(t *testing.T) {
 	})
 
 	Convey("get should return entry of sys types", t, func() {
-		ShouldLog(h.nucleus.alog, `{"Identity":"Herbert \u003ch@bert.com\u003e","PublicKey":[8,1,18,32,114,212,127,24,221,160,71,228,241,188,163,176,20,126,21,124,88,165,138,197,78,248,146,5,253,129,108,45,27,163,41,83],"Revocation":[]}`, func() {
+		ShouldLog(h.nucleus.alog, func() {
 			_, err := NewJSRibosome(h, &Zome{RibosomeType: JSRibosomeType, Code: fmt.Sprintf(`debug(get("%s"));`, h.agentHash.String())})
 			So(err, ShouldBeNil)
-		})
-		ShouldLog(h.nucleus.alog, `[8,1,18,32,114,212,127,24,221,160,71,228,241,188,163,176,20,126,21,124,88,165,138,197,78,248,146,5,253,129,108,45,27,163,41,83]`, func() {
+		}, `{"Identity":"Herbert \u003ch@bert.com\u003e","PublicKey":[8,1,18,32,114,212,127,24,221,160,71,228,241,188,163,176,20,126,21,124,88,165,138,197,78,248,146,5,253,129,108,45,27,163,41,83],"Revocation":[]}`)
+		ShouldLog(h.nucleus.alog, func() {
 			_, err := NewJSRibosome(h, &Zome{RibosomeType: JSRibosomeType, Code: fmt.Sprintf(`debug(get("%s"));`, h.nodeID.Pretty())})
 			So(err, ShouldBeNil)
-		})
+		}, `[8,1,18,32,114,212,127,24,221,160,71,228,241,188,163,176,20,126,21,124,88,165,138,197,78,248,146,5,253,129,108,45,27,163,41,83]`)
 	})
 
 	Convey("get should return entry type", t, func() {

--- a/node.go
+++ b/node.go
@@ -112,7 +112,12 @@ type Message struct {
 	Body interface{}
 }
 
-var BytesSentChan chan int64
+type BytesSent struct {
+	Bytes   int64
+	MsgType MsgType
+}
+
+var BytesSentChan chan BytesSent
 
 // Node represents a node in the network
 type Node struct {
@@ -467,7 +472,8 @@ func (node *Node) respondWith(s net.Stream, err error, body interface{}) {
 		Infof("Response failed: write returned error: %v", err)
 	}
 	if BytesSentChan != nil {
-		BytesSentChan <- int64(n)
+		b := BytesSent{Bytes: int64(n), MsgType: m.Type}
+		BytesSentChan <- b
 	}
 }
 
@@ -545,7 +551,8 @@ func (node *Node) Send(ctx context.Context, proto int, addr peer.ID, m *Message)
 		err = errors.New("unable to send all data")
 	}
 	if BytesSentChan != nil {
-		BytesSentChan <- int64(n)
+		b := BytesSent{Bytes: int64(n), MsgType: m.Type}
+		BytesSentChan <- b
 	}
 
 	// decode the response

--- a/service.go
+++ b/service.go
@@ -134,25 +134,27 @@ type TestFixtures struct {
 
 // TestSet holds a set of tests plus configuration and fixture data for those tests
 type TestSet struct {
-	Tests    []TestData
-	Identity string
-	Fixtures TestFixtures
+	Tests     []TestData
+	Identity  string
+	Fixtures  TestFixtures
+	Benchmark bool // activate benchmarking for all tests
 }
 
 // TestData holds a test entry for a chain
 type TestData struct {
-	Convey   string        // a human readable description of the tests intent
-	Zome     string        // the zome in which to find the function
-	FnName   string        // the function to call
-	Input    interface{}   // the function's input
-	Output   interface{}   // the expected output to match against (full match)
-	Err      string        // the expected error to match against
-	Regexp   string        // the expected out to match again (regular expression)
-	Time     time.Duration // offset in milliseconds from the start of the test at which to run this test.
-	Wait     time.Duration // time in milliseconds to wait before running this test from when the previous ran
-	Exposure string        // the exposure context for the test call (defaults to ZOME_EXPOSURE)
-	Raw      bool          // set to true if we should ignore fnName and just call input as raw code in the zome, useful for testing helper functions and validation functions
-	Repeat   int           // number of times to repeat this test, useful for scenario testing
+	Convey    string        // a human readable description of the tests intent
+	Zome      string        // the zome in which to find the function
+	FnName    string        // the function to call
+	Input     interface{}   // the function's input
+	Output    interface{}   // the expected output to match against (full match)
+	Err       string        // the expected error to match against
+	Regexp    string        // the expected out to match again (regular expression)
+	Time      time.Duration // offset in milliseconds from the start of the test at which to run this test.
+	Wait      time.Duration // time in milliseconds to wait before running this test from when the previous ran
+	Exposure  string        // the exposure context for the test call (defaults to ZOME_EXPOSURE)
+	Raw       bool          // set to true if we should ignore fnName and just call input as raw code in the zome, useful for testing helper functions and validation functions
+	Repeat    int           // number of times to repeat this test, useful for scenario testing
+	Benchmark bool          // activate benchmarking for this test
 }
 
 // IsDevMode is used to enable certain functionality when developing holochains, for example,

--- a/test.go
+++ b/test.go
@@ -136,18 +136,20 @@ func CleanupTestChain(h *Holochain, d string) {
 	CleanupTestDir(d)
 }
 
-func ShouldLog(log *Logger, message string, fn func()) {
+func ShouldLog(log *Logger, fn func(), messages ...string) {
 	var buf bytes.Buffer
 	w := log.w
 	log.w = &buf
 	e := log.Enabled
 	log.Enabled = true
 	fn()
-	matched := strings.Index(buf.String(), message) >= 0
-	if matched {
-		So(matched, ShouldBeTrue)
-	} else {
-		So(buf.String(), ShouldEqual, message)
+	for _, message := range messages {
+		matched := strings.Index(buf.String(), message) >= 0
+		if matched {
+			So(matched, ShouldBeTrue)
+		} else {
+			So(buf.String(), ShouldEqual, message)
+		}
 	}
 	log.Enabled = e
 	log.w = w

--- a/test.go
+++ b/test.go
@@ -166,3 +166,16 @@ func compareFile(path1 string, path2 string, fileName string) bool {
 	}
 	return (string(src) == string(dst)) && (string(src) != "")
 }
+
+func SetIdentity(h *Holochain, identity AgentIdentity) {
+	agent := h.Agent()
+	SetAgentIdentity(agent, identity)
+	h.nodeID, h.nodeIDStr, _ = agent.NodeID()
+}
+
+func SetAgentIdentity(agent Agent, identity AgentIdentity) {
+	agent.SetIdentity(identity)
+	var seed io.Reader
+	seed = MakeTestSeed(string(identity))
+	agent.GenKeys(seed)
+}

--- a/utils.go
+++ b/utils.go
@@ -121,6 +121,15 @@ func FileExists(pathParts ...string) bool {
 	return info.Mode().IsRegular()
 }
 
+func FileSize(pathParts ...string) int64 {
+	path := filepath.Join(pathParts...)
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0
+	}
+	return info.Size()
+}
+
 func filePerms(pathParts ...string) (perms os.FileMode, err error) {
 	var fi os.FileInfo
 	fi, err = os.Stat(filepath.Join(pathParts...))

--- a/zygosome_test.go
+++ b/zygosome_test.go
@@ -134,10 +134,10 @@ func TestNewZygoRibosome(t *testing.T) {
 			So(err, ShouldBeNil)
 			So(z.lastResult.(*zygo.SexpStr).S, ShouldEqual, "a bogus test holochain")
 
-			ShouldLog(&infoLog, "Warning: Getting special properties via property() is deprecated as of 3. Returning nil values.  Use App* instead\n", func() {
+			ShouldLog(&infoLog, func() {
 				_, err = z.Run(`(property "` + ID_PROPERTY + `")`)
 				So(err, ShouldBeNil)
-			})
+			}, "Warning: Getting special properties via property() is deprecated as of 3. Returning nil values.  Use App* instead\n")
 
 		})
 
@@ -180,10 +180,10 @@ func TestNewZygoRibosome(t *testing.T) {
 				panic(err)
 			}
 
-			ShouldLog(h.nucleus.alog, fmt.Sprintf(`[ (hash Side:0 ToApp:"QmY8Mzg9F69e5P9AoQPYat655HEhc1TVGs11tmfNSzkqto")  (hash Side:1 Token:"%s")]`, token), func() {
+			ShouldLog(h.nucleus.alog, func() {
 				_, err := z.Run(`(testGetBridges)`)
 				So(err, ShouldBeNil)
-			})
+			}, fmt.Sprintf(`[ (hash Side:0 ToApp:"QmY8Mzg9F69e5P9AoQPYat655HEhc1TVGs11tmfNSzkqto")  (hash Side:1 Token:"%s")]`, token))
 
 		})
 
@@ -216,18 +216,18 @@ func TestNewZygoRibosome(t *testing.T) {
 		})
 
 		Convey("send", func() {
-			ShouldLog(h.nucleus.alog, `result was: "{\"pong\":\"foobar\"}"`, func() {
+			ShouldLog(h.nucleus.alog, func() {
 				_, err := z.Run(`(debug (concat "result was: " (str (hget (send App_Key_Hash (hash ping: "foobar")) %result))))`)
 				So(err, ShouldBeNil)
-			})
+			}, `result was: "{\"pong\":\"foobar\"}"`)
 		})
 		Convey("send async", func() {
-			ShouldLog(h.nucleus.alog, `async result of message with 123 was: (hash pong:"foobar")`, func() {
+			ShouldLog(h.nucleus.alog, func() {
 				_, err := z.Run(`(send App_Key_Hash (hash ping: "foobar") (hash Callback: (hash Function: "asyncPing" ID:"123")))`)
 				So(err, ShouldBeNil)
 				err = <-h.asyncSends
 				So(err, ShouldBeNil)
-			})
+			}, `async result of message with 123 was: (hash pong:"foobar")`)
 		})
 	})
 }
@@ -251,34 +251,34 @@ func TestZygoQuery(t *testing.T) {
 		commit(h, "secret", "bar")
 		commit(h, "profile", `{"firstName":"Zippy","lastName":"Pinhead"}`)
 
-		ShouldLog(h.nucleus.alog, `["2" "4"]`, func() {
+		ShouldLog(h.nucleus.alog, func() {
 			_, err := z.Run(`(debug (str (query (hash Constrain: (hash EntryTypes: ["evenNumbers"])))))`)
 			So(err, ShouldBeNil)
-		})
-		ShouldLog(h.nucleus.alog, `["QmQzp4h9pvLVJHUx6rFxxC4ViqgnznYqXvoa9HsJgACMmi" "QmS4bKx7zZt6qoX2om5M5ik3X2k4Fco2nFx82CDJ3iVKj2"]`, func() {
+		}, `["2" "4"]`)
+		ShouldLog(h.nucleus.alog, func() {
 			_, err := z.Run(`(debug (str (query (hash Return: (hash Hashes: true) Constrain: (hash EntryTypes:["evenNumbers"])))))`)
 			So(err, ShouldBeNil)
-		})
-		ShouldLog(h.nucleus.alog, `[ (hash Hash:"QmQzp4h9pvLVJHUx6rFxxC4ViqgnznYqXvoa9HsJgACMmi" Entry:"2")  (hash Hash:"QmS4bKx7zZt6qoX2om5M5ik3X2k4Fco2nFx82CDJ3iVKj2" Entry:"4")]`, func() {
+		}, `["QmQzp4h9pvLVJHUx6rFxxC4ViqgnznYqXvoa9HsJgACMmi" "QmS4bKx7zZt6qoX2om5M5ik3X2k4Fco2nFx82CDJ3iVKj2"]`)
+		ShouldLog(h.nucleus.alog, func() {
 			_, err := z.Run(`(debug (str (query ( hash Return: (hash Hashes:true Entries:true) Constrain: (hash EntryTypes: ["evenNumbers"])))))`)
 			So(err, ShouldBeNil)
-		})
-		ShouldLog(h.nucleus.alog, `"Type":"evenNumbers","EntryLink":"QmQzp4h9pvLVJHUx6rFxxC4ViqgnznYqXvoa9HsJgACMmi","HeaderLink":"Qm`, func() {
+		}, `[ (hash Hash:"QmQzp4h9pvLVJHUx6rFxxC4ViqgnznYqXvoa9HsJgACMmi" Entry:"2")  (hash Hash:"QmS4bKx7zZt6qoX2om5M5ik3X2k4Fco2nFx82CDJ3iVKj2" Entry:"4")]`)
+		ShouldLog(h.nucleus.alog, func() {
 			_, err := z.Run(`(debug (query (hash Return: (hash Headers:true Entries:true) Constrain: (hash EntryTypes: ["evenNumbers"]))))`)
 			So(err, ShouldBeNil)
-		})
-		ShouldLog(h.nucleus.alog, `["foo","bar"]`, func() {
+		}, `"Type":"evenNumbers","EntryLink":"QmQzp4h9pvLVJHUx6rFxxC4ViqgnznYqXvoa9HsJgACMmi","HeaderLink":"Qm`)
+		ShouldLog(h.nucleus.alog, func() {
 			_, err := z.Run(`(debug (query (hash Constrain: (hash EntryTypes: ["secret"]))))`)
 			So(err, ShouldBeNil)
-		})
-		ShouldLog(h.nucleus.alog, `["{\"firstName\":\"Zippy\",\"lastName\":\"Pinhead\"}"]`, func() {
+		}, `["foo","bar"]`)
+		ShouldLog(h.nucleus.alog, func() {
 			_, err := z.Run(`(debug (str (query (hash Constrain: (hash EntryTypes: ["profile"])))))`)
 			So(err, ShouldBeNil)
-		})
-		ShouldLog(h.nucleus.alog, `["{\"Identity\":\"Herbert \\u003ch@bert.com\\u003e\",\"Revocation\":null,\"PublicKey\":\"CAESIHLUfxjdoEfk8byjsBR+FXxYpYrFTviSBf2BbC0boylT\"}"]`, func() {
+		}, `["{\"firstName\":\"Zippy\",\"lastName\":\"Pinhead\"}"]`)
+		ShouldLog(h.nucleus.alog, func() {
 			_, err := z.Run(`(debug (str (query (hash Constrain: (hash EntryTypes: ["%agent"])))))`)
 			So(err, ShouldBeNil)
-		})
+		}, `["{\"Identity\":\"Herbert \\u003ch@bert.com\\u003e\",\"Revocation\":null,\"PublicKey\":\"CAESIHLUfxjdoEfk8byjsBR+FXxYpYrFTviSBf2BbC0boylT\"}"]`)
 	})
 }
 func TestZygoGenesis(t *testing.T) {
@@ -302,20 +302,20 @@ func TestZygoBridgeGenesis(t *testing.T) {
 
 	fakeToApp, _ := NewHash("QmVGtdTZdTFaLsaj2RwdVG8jcjNNcp1DE914DKZ2kHmXHx")
 	Convey("it should fail if the bridge genesis function returns false", t, func() {
-		ShouldLog(&h.Config.Loggers.App, h.dnaHash.String()+" test data", func() {
+		ShouldLog(&h.Config.Loggers.App, func() {
 			z, err := NewZygoRibosome(h, &Zome{RibosomeType: ZygoRibosomeType, Code: `(defn bridgeGenesis [side app data] (begin (debug (concat app " " data)) false))`})
 			So(err, ShouldBeNil)
 			err = z.BridgeGenesis(BridgeFrom, h.dnaHash, "test data")
 			So(err.Error(), ShouldEqual, "bridgeGenesis failed")
-		})
+		}, h.dnaHash.String()+" test data")
 	})
 	Convey("it should work if the bridge genesis function returns true", t, func() {
-		ShouldLog(&h.Config.Loggers.App, fakeToApp.String()+" test data", func() {
+		ShouldLog(&h.Config.Loggers.App, func() {
 			z, err := NewZygoRibosome(h, &Zome{RibosomeType: ZygoRibosomeType, Code: `(defn bridgeGenesis [side app data] (begin (debug (concat app " " data)) true))`})
 			So(err, ShouldBeNil)
 			err = z.BridgeGenesis(BridgeTo, fakeToApp, "test data")
 			So(err, ShouldBeNil)
-		})
+		}, fakeToApp.String()+" test data")
 	})
 }
 
@@ -380,17 +380,17 @@ func TestZyValidateCommit(t *testing.T) {
 		v, err := NewZygoRibosome(&h, &Zome{RibosomeType: ZygoRibosomeType, Code: `(defn validateCommit [name entry header pkg sources] (debug name) (debug entry) (debug header) (debug sources) (debug pkg) true)`})
 		So(err, ShouldBeNil)
 		d := EntryDef{Name: "evenNumbers", DataFormat: DataFormatString}
-		ShouldLog(&h.Config.Loggers.App, `evenNumbers
-foo
-{"EntryLink":"QmNiCwBNA8MWDADTFVq1BonUEJbS2SvjAoNkZZrhEwcuU2","Type":"evenNumbers","Time":"1970-01-01T00:00:01Z"}
-["fakehashvalue"]
-{"Atype":"hash"}
-`, func() {
+		ShouldLog(&h.Config.Loggers.App, func() {
 			a := NewCommitAction("oddNumbers", &GobEntry{C: "foo"})
 			a.header = &hdr
 			err = v.ValidateAction(a, &d, nil, []string{"fakehashvalue"})
 			So(err, ShouldBeNil)
-		})
+		}, `evenNumbers
+foo
+{"EntryLink":"QmNiCwBNA8MWDADTFVq1BonUEJbS2SvjAoNkZZrhEwcuU2","Type":"evenNumbers","Time":"1970-01-01T00:00:01Z"}
+["fakehashvalue"]
+{"Atype":"hash"}
+`)
 	})
 	Convey("should run an entry value against the defined validator for string data", t, func() {
 		v, err := NewZygoRibosome(&h, &Zome{RibosomeType: ZygoRibosomeType, Code: `(defn validateCommit [name entry header pkg sources] (cond (== entry "fish") true false))`})
@@ -554,10 +554,10 @@ func TestZygoDHT(t *testing.T) {
 	})
 
 	Convey("get should return entry of sys types", t, func() {
-		ShouldLog(h.nucleus.alog, `{"result":"{\"Identity\":\"Herbert \\u003ch@bert.com\\u003e\",\"Revocation\":null,\"PublicKey\":\"CAESIHLUfxjdoEfk8byjsBR+FXxYpYrFTviSBf2BbC0boylT\"}"}`, func() {
+		ShouldLog(h.nucleus.alog, func() {
 			_, err := NewZygoRibosome(h, &Zome{RibosomeType: ZygoRibosomeType, Code: fmt.Sprintf(`(debug (get "%s"))`, h.agentHash.String())})
 			So(err, ShouldBeNil)
-		})
+		}, `{"result":"{\"Identity\":\"Herbert \\u003ch@bert.com\\u003e\",\"Revocation\":null,\"PublicKey\":\"CAESIHLUfxjdoEfk8byjsBR+FXxYpYrFTviSBf2BbC0boylT\"}"}`)
 	})
 
 	Convey("get should return entry type", t, func() {


### PR DESCRIPTION
You can now set `Benchmark:true` in an individual test, or, for testing a scenario you can pass in a benchmark flag.  e.g.:  `hcdev -mdns=true -no-nat-upnp scenario -benchmarks benchmark`  (this example runs the [dao benchmark scenario](https://github.com/Holochain/dao/tree/master/test/benchmark)