### PR TITLE
Added Config options to Ribosomes, and JS error throwing, closes #437

### DIFF
--- a/action.go
+++ b/action.go
@@ -61,6 +61,11 @@ type Action interface {
 	Args() []Arg
 }
 
+type ArgsAction interface {
+	Args() []Arg
+	Do(h *Holochain) (response interface{}, err error)
+}
+
 // CommittingAction provides an abstraction for grouping actions which carry Entry data
 type CommittingAction interface {
 	Name() string
@@ -426,7 +431,7 @@ func (a *ActionVerifySignature) Args() []Arg {
 	return []Arg{{Name: "signature", Type: StringArg}, {Name: "data", Type: StringArg}, {Name: "pubKey", Type: StringArg}}
 }
 
-func (a *ActionVerifySignature) Do(h *Holochain) (response bool, err error) {
+func (a *ActionVerifySignature) Do(h *Holochain) (response interface{}, err error) {
 	var b bool
 	var pubKeyIC ic.PubKey
 	var sig []byte

--- a/action.go
+++ b/action.go
@@ -638,9 +638,7 @@ func (a *ActionGet) Do(h *Holochain) (response interface{}, err error) {
 		}
 		resp := GetResp{Entry: *entry.(*GobEntry)}
 		mask := a.options.GetMask
-		if (mask & GetMaskEntryType) != 0 {
-			resp.EntryType = entryType
-		}
+		resp.EntryType = entryType
 		if (mask & GetMaskEntry) != 0 {
 			resp.Entry = *entry.(*GobEntry)
 		}
@@ -703,6 +701,7 @@ func (a *ActionGet) Receive(dht *DHT, msg *Message, retries int) (response inter
 
 	if err == nil {
 		if (mask & GetMaskEntry) != 0 {
+			resp.EntryType = entryType
 			switch entryType {
 			case DNAEntryType:
 				// TODO: make this add the requester to the blockedlist rather than panicing, see ticket #421

--- a/apptest/apptest.go
+++ b/apptest/apptest.go
@@ -517,7 +517,16 @@ func DoTest(h *Holochain, name string, i int, fixtures TestFixtures, t TestData,
 			logBenchmark(info, testID, b)
 		}
 
-		var expectedResult, expectedError = output, t.Err
+		var expectedResult, expectedErrorRaw = output, t.Err
+		var expectedError string
+
+		if expectedErrorRaw != nil {
+			expectedError, err = toStringByType(expectedErrorRaw)
+			if err != nil {
+				panic("unable to covert expected error to string")
+			}
+		}
+
 		var expectedResultRegexp = t.Regexp
 		//====================
 		history.lastResults[2] = history.lastResults[1]

--- a/apptest/apptest_test.go
+++ b/apptest/apptest_test.go
@@ -138,7 +138,7 @@ func TestTestOne(t *testing.T) {
 		}, `========================================
 Test: 'testSet1' starting...
 ========================================
-Test 'testSet1.0' t+0ms: { zySampleZome addEven 2 %h%   0s 0s  false 0 false}
+Test 'testSet1.0' t+0ms: { zySampleZome addEven 2 %h% <nil>  0s 0s  false 0 false}
 `)
 	})
 }

--- a/dht_test.go
+++ b/dht_test.go
@@ -505,7 +505,7 @@ func TestActionReceiver(t *testing.T) {
 		resp = r.(GetResp)
 		So(resp.Entry.C, ShouldBeNil)
 		So(fmt.Sprintf("%v", resp.Sources), ShouldEqual, fmt.Sprintf("[%v]", h.nodeIDStr))
-		So(resp.EntryType, ShouldEqual, "")
+		So(resp.EntryType, ShouldEqual, "evenNumbers") // you allways get the entry type even if not in getmask at this level (ActionReceiver) because we have to be able to look up the definition to interpret the contents
 
 		m = h.node.NewMessage(GET_REQUEST, GetReq{H: hash, GetMask: GetMaskEntry + GetMaskSources})
 		r, err = ActionReceiver(h, m)
@@ -857,12 +857,17 @@ func TestDHTMultiNode(t *testing.T) {
 				req := GetReq{H: HashFromPeerID(h1.nodeID), StatusMask: options.StatusMask, GetMask: options.GetMask}
 				response, err := NewGetAction(req, &options).Do(h2)
 				if err != nil {
-					//fmt.Printf("FAIL   : %v couldn't get from %v\n", h2.nodeID, h1.nodeID)
+					//          fmt.Printf("FAIL   : %v couldn't get from %v err: %err\n", h2.nodeID, h1.nodeID, err)
 				} else {
+					responseStr := fmt.Sprintf("%v", response)
 					pk, _ := h1.agent.PubKey().Bytes()
-					if fmt.Sprintf("%v", response) == fmt.Sprintf("{{%v}  [] }", pk) {
+					expectedResponseStr := fmt.Sprintf("{{%v} %s [] }", pk, `%%key`)
+					if responseStr == expectedResponseStr {
 						connections += 1
-						//	fmt.Printf("SUCCESS: %v got from          %v\n", h2.nodeID, h1.nodeID)
+						//            fmt.Printf("SUCCESS: %v got from          %v\n", h2.nodeID, h1.nodeID)
+					} else {
+						//            fmt.Printf("Expected:%s\n", expectedResponseStr)
+						//            fmt.Printf("Got     :%s\n", responseStr)
 					}
 				}
 			}

--- a/jsribosome.go
+++ b/jsribosome.go
@@ -523,6 +523,21 @@ type fnData struct {
 	fn func([]Arg, ArgsAction, otto.FunctionCall) (otto.Value, error)
 }
 
+func makeOttoObjectFromGetResp(h *Holochain, jsr *JSRibosome, getResp *GetResp) (result interface{}, err error) {
+	_, def, err := h.GetEntryDef(getResp.EntryType)
+	if err != nil {
+		return
+	}
+	if def.DataFormat == DataFormatJSON {
+		json := getResp.Entry.Content().(string)
+		code := `(` + json + `)`
+		result, err = jsr.vm.Object(code)
+	} else {
+		result = getResp.Entry.Content()
+	}
+	return
+}
+
 // NewJSRibosome factory function to build a javascript execution environment for a zome
 func NewJSRibosome(h *Holochain, zome *Zome) (n Ribosome, err error) {
 	jsr := JSRibosome{
@@ -927,7 +942,12 @@ func NewJSRibosome(h *Holochain, zome *Zome) (n Ribosome, err error) {
 					if mask&GetMaskEntry != 0 {
 						if GetMaskEntry == mask {
 							singleValueReturn = true
-							result, err = jsr.vm.ToValue(getResp.Entry.Content())
+							var entry interface{}
+							entry, err = makeOttoObjectFromGetResp(h, &jsr, &getResp)
+							if err != nil {
+								return
+							}
+							result, err = jsr.vm.ToValue(entry)
 						}
 					}
 					if mask&GetMaskEntryType != 0 {
@@ -945,7 +965,12 @@ func NewJSRibosome(h *Holochain, zome *Zome) (n Ribosome, err error) {
 					if err == nil && !singleValueReturn {
 						respObj := make(map[string]interface{})
 						if mask&GetMaskEntry != 0 {
-							respObj["Entry"] = getResp.Entry.Content()
+							var entry interface{}
+							entry, err = makeOttoObjectFromGetResp(h, &jsr, &getResp)
+							if err != nil {
+								return
+							}
+							respObj["Entry"] = entry
 						}
 						if mask&GetMaskEntryType != 0 {
 							respObj["EntryType"] = getResp.EntryType

--- a/jsribosome.go
+++ b/jsribosome.go
@@ -496,7 +496,7 @@ func jsProcessArgs(jsr *JSRibosome, args []Arg, oArgs []otto.Value) (err error) 
 }
 
 const (
-	HolochainErrorPrefix = "Holochain Error"
+	HolochainErrorPrefix = "HolochainError"
 )
 
 func mkOttoErr(jsr *JSRibosome, msg string) otto.Value {
@@ -1233,7 +1233,7 @@ func NewJSRibosome(h *Holochain, zome *Zome) (n Ribosome, err error) {
 	l += `
 // helper function to determine if value returned from holochain function is an error
 function isErr(result) {
-    return ((typeof result === 'object') && result.name == "Holochain Error");
+    return ((typeof result === 'object') && result.name == "` + HolochainErrorPrefix + `");
 }`
 
 	_, err = jsr.Run(l + zome.Code)

--- a/jsribosome_test.go
+++ b/jsribosome_test.go
@@ -264,7 +264,7 @@ func TestNewJSRibosome(t *testing.T) {
 		})
 		Convey("bridge", func() {
 			_, err := z.Run(`bridge("QmVGtdTZdTFaLsaj2RwdVG8jcjNNcp1DE914DKZ2kHmXHw","zySampleZome","testStrFn1","foo")`)
-			So(err.Error(), ShouldEqual, `{"errorMessage":"no active bridge","function":"bridge","name":"Holochain Error","source":{}}`)
+			So(err.Error(), ShouldEqual, `{"errorMessage":"no active bridge","function":"bridge","name":"HolochainError","source":{}}`)
 
 			// TODO
 			// This test can't work because of the import cycle that we can't import
@@ -371,7 +371,7 @@ func TestJSQuery(t *testing.T) {
 		}, `[{"Identity":"Herbert \u003ch@bert.com\u003e","PublicKey":"CAESIHLUfxjdoEfk8byjsBR+FXxYpYrFTviSBf2BbC0boylT","Revocation":null}]`)
 
 		_, err := z.Run(`debug(query({Constrain:{EntryTypes:["%dna"]}}))`)
-		So(err.Error(), ShouldEqual, `{"errorMessage":"data format not implemented: _DNA","function":"query","name":"Holochain Error","source":{}}`)
+		So(err.Error(), ShouldEqual, `{"errorMessage":"data format not implemented: _DNA","function":"query","name":"HolochainError","source":{}}`)
 
 		ShouldLog(h.nucleus.alog, func() {
 			_, err := z.Run(`debug(query({Constrain:{EntryTypes:["rating"]}}))`)
@@ -640,7 +640,7 @@ func TestJSDHT(t *testing.T) {
 	hash, _ := NewHash("QmY8Mzg9F69e5P9AoQPYat6x5HEhc1TVGs11tmfNSzkqh2")
 	Convey("get should return hash not found if it doesn't exist", t, func() {
 		_, err := NewJSRibosome(h, &Zome{RibosomeType: JSRibosomeType, Code: fmt.Sprintf(`get("%s");`, hash.String())})
-		So(err.Error(), ShouldEqual, `{"errorMessage":"hash not found","function":"get","name":"Holochain Error","source":{}}`)
+		So(err.Error(), ShouldEqual, `{"errorMessage":"hash not found","function":"get","name":"HolochainError","source":{}}`)
 	})
 
 	// add an entry onto the chain
@@ -841,7 +841,7 @@ func TestJSDHT(t *testing.T) {
 		So(err, ShouldBeNil)
 
 		v, err = NewJSRibosome(h, &Zome{RibosomeType: JSRibosomeType, Code: fmt.Sprintf(`get("%s");`, hash.String())})
-		So(err.Error(), ShouldEqual, `{"errorMessage":"hash deleted","function":"get","name":"Holochain Error","source":{}}`)
+		So(err.Error(), ShouldEqual, `{"errorMessage":"hash deleted","function":"get","name":"HolochainError","source":{}}`)
 
 		v, err = NewJSRibosome(h, &Zome{RibosomeType: JSRibosomeType, Code: fmt.Sprintf(`get("%s",{StatusMask:HC.Status.Deleted});`, hash.String())})
 		So(err, ShouldBeNil)
@@ -855,7 +855,7 @@ func TestJSDHT(t *testing.T) {
 	Convey("updateAgent function without options should fail", t, func() {
 		_, err := NewJSRibosome(h, &Zome{RibosomeType: JSRibosomeType,
 			Code: fmt.Sprintf(`updateAgent({})`)})
-		So(err.Error(), ShouldEqual, `{"errorMessage":"expecting identity and/or revocation option","function":"updateAgent","name":"Holochain Error","source":{}}`)
+		So(err.Error(), ShouldEqual, `{"errorMessage":"expecting identity and/or revocation option","function":"updateAgent","name":"HolochainError","source":{}}`)
 	})
 
 	Convey("updateAgent function should commit a new agent entry", t, func() {

--- a/jsribosome_test.go
+++ b/jsribosome_test.go
@@ -697,6 +697,17 @@ func TestJSDHT(t *testing.T) {
 	})
 
 	profileHash := commit(h, "profile", `{"firstName":"Zippy","lastName":"Pinhead"}`)
+
+	Convey("get should parsed JSON object of JSON type entries", t, func() {
+		v, err := NewJSRibosome(h, &Zome{RibosomeType: JSRibosomeType, Code: fmt.Sprintf(`get("%s");`, profileHash.String())})
+		So(err, ShouldBeNil)
+		z := v.(*JSRibosome)
+		So(z.lastResult.Class(), ShouldEqual, "Object")
+		x, err := z.lastResult.Export()
+		So(err, ShouldBeNil)
+		So(fmt.Sprintf("%v", x), ShouldEqual, `map[firstName:Zippy lastName:Pinhead]`)
+	})
+
 	reviewHash := commit(h, "review", "this is my bogus review of some thing")
 
 	commit(h, "rating", fmt.Sprintf(`{"Links":[{"Base":"%s","Link":"%s","Tag":"4stars"},{"Base":"%s","Link":"%s","Tag":"4stars"}]}`, hash.String(), profileHash.String(), hash.String(), reviewHash.String()))
@@ -829,7 +840,7 @@ func TestJSDHT(t *testing.T) {
 		z = v.(*JSRibosome)
 		x, err := z.lastResult.Export()
 		So(err, ShouldBeNil)
-		So(fmt.Sprintf("%v", x), ShouldEqual, `{"firstName":"Zippy","lastName":"ThePinhead"}`)
+		So(fmt.Sprintf("%v", x), ShouldEqual, `map[firstName:Zippy lastName:ThePinhead]`)
 	})
 
 	Convey("remove function should mark item deleted", t, func() {

--- a/service.go
+++ b/service.go
@@ -1565,7 +1565,7 @@ func TestingAppAppPackage() string {
 	"Zome":   "jsSampleZome",
 	"FnName": "addOdd",
 	"Input":  "2",
-	"Err":    {"errorMessage":"Validation Failed","function":"commit","name":"Holochain Error","source":{"column":"28","functionName":"addOdd","line":"45"}}
+	"Err":    {"errorMessage":"Validation Failed","function":"commit","name":"` + HolochainErrorPrefix + `","source":{"column":"28","functionName":"addOdd","line":"45"}}
     },
     {
 	"Zome":   "zySampleZome",

--- a/service.go
+++ b/service.go
@@ -106,6 +106,7 @@ type ZomeFile struct {
 	Functions    []FunctionDef
 	BridgeFuncs  []string // functions in zome that can be bridged to by fromApp
 	BridgeTo     string   // dna Hash of toApp that this zome is a client of
+	Config       map[string]interface{}
 }
 
 type DNAFile struct {
@@ -147,7 +148,7 @@ type TestData struct {
 	FnName    string        // the function to call
 	Input     interface{}   // the function's input
 	Output    interface{}   // the expected output to match against (full match)
-	Err       string        // the expected error to match against
+	Err       interface{}   // the expected error to match against
 	Regexp    string        // the expected out to match again (regular expression)
 	Time      time.Duration // offset in milliseconds from the start of the test at which to run this test.
 	Wait      time.Duration // time in milliseconds to wait before running this test from when the previous ran
@@ -392,6 +393,7 @@ func (s *Service) loadDNA(path string, filename string, format string) (dnaP *DN
 		dna.Zomes[i].Description = zome.Description
 		dna.Zomes[i].RibosomeType = zome.RibosomeType
 		dna.Zomes[i].Functions = zome.Functions
+		dna.Zomes[i].Config = zome.Config
 		dna.Zomes[i].BridgeFuncs = zome.BridgeFuncs
 		if zome.BridgeTo != "" {
 			dna.Zomes[i].BridgeTo, err = NewHash(zome.BridgeTo)
@@ -957,6 +959,7 @@ func (s *Service) saveDNAFile(root string, dna *DNA, encodingFormat string, over
 			Functions:    z.Functions,
 			BridgeFuncs:  z.BridgeFuncs,
 			BridgeTo:     z.BridgeTo.String(),
+			Config:       z.Config,
 		}
 
 		for _, e := range z.Entries {
@@ -1562,7 +1565,7 @@ func TestingAppAppPackage() string {
 	"Zome":   "jsSampleZome",
 	"FnName": "addOdd",
 	"Input":  "2",
-	"Err":    "Validation Failed"
+	"Err":    {"errorMessage":"Validation Failed","function":"commit","name":"Holochain Error","source":{"column":"28","functionName":"addOdd","line":"45"}}
     },
     {
 	"Zome":   "zySampleZome",

--- a/zome.go
+++ b/zome.go
@@ -19,6 +19,7 @@ type Zome struct {
 	Functions    []FunctionDef
 	BridgeFuncs  []string // functions in zome that can be bridged to by fromApp
 	BridgeTo     Hash     // dna Hash of toApp that this zome is a client of
+	Config       map[string]interface{}
 }
 
 // GetEntryDef returns the entry def structure


### PR DESCRIPTION
throwing an error is now default for JS ribosome, but the old pattern of returning an error can be enabled with the config option "returnError" set to true.