### PR TITLE
561 dump json

### DIFF
--- a/cmd/hcadmin/hcadmin.go
+++ b/cmd/hcadmin/hcadmin.go
@@ -8,11 +8,12 @@ package main
 import (
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
+
 	holo "github.com/metacurrency/holochain"
 	"github.com/metacurrency/holochain/cmd"
 	"github.com/urfave/cli"
-	"os"
-	"path/filepath"
 )
 
 var debug bool
@@ -24,7 +25,7 @@ func setupApp() (app *cli.App) {
 	app.Usage = "holochain administration tool"
 	app.Version = fmt.Sprintf("0.0.3 (holochain %s)", holo.VersionStr)
 
-	var dumpChain, dumpDHT bool
+	var dumpChain, dumpDHT, json bool
 	var root string
 	var service *holo.Service
 	var bridgeToAppData, bridgeFromAppData string
@@ -85,6 +86,11 @@ func setupApp() (app *cli.App) {
 					Name:        "dht",
 					Destination: &dumpDHT,
 				},
+				cli.BoolFlag{
+					Name:        "json",
+					Destination: &json,
+					Usage:       "Dump as JSON string",
+				},
 			},
 			Action: func(c *cli.Context) error {
 				h, err := cmd.GetHolochain(c.Args().First(), service, "dump")
@@ -97,7 +103,11 @@ func setupApp() (app *cli.App) {
 				}
 				dnaHash := h.DNAHash()
 				if dumpChain {
-					fmt.Printf("Chain for: %s\n%v", dnaHash, h.Chain())
+					if json {
+						fmt.Println(h.Chain().JSON())
+					} else {
+						fmt.Printf("Chain for: %s\n%v", dnaHash, h.Chain())
+					}
 				}
 				if dumpDHT {
 					fmt.Printf("DHT for: %s\n%v", dnaHash, h.DHT())

--- a/cmd/hcadmin/hcadmin_test.go
+++ b/cmd/hcadmin/hcadmin_test.go
@@ -183,6 +183,38 @@ func TestBridge(t *testing.T) {
 	})
 }
 
+func TestDumpChainAsJSON(t *testing.T) {
+	Convey("Given a joined chain", t, func() {
+		d := holo.SetupTestDir()
+		defer os.RemoveAll(d)
+
+		app := setupApp()
+		_, err := runAppWithStdoutCapture(app, []string{"hcadmin", "-path", d, "init", "test-identity"})
+		if err != nil {
+			panic(err)
+		}
+
+		err = holo.WriteFile([]byte(holo.BasicTemplateAppPackage), d, "appPackage."+holo.BasicTemplateAppPackageFormat)
+		if err != nil {
+			panic(err)
+		}
+
+		app = setupApp()
+		_, err = runAppWithStdoutCapture(app, []string{"hcadmin", "-verbose", "-path", d, "join", filepath.Join(d, "appPackage."+holo.BasicTemplateAppPackageFormat), "testApp"})
+		if err != nil {
+			panic(err)
+		}
+
+		Convey("dump -chain -json should show chain entries as a json", func() {
+			app = setupApp()
+			out, err := runAppWithStdoutCapture(app, []string{"hcadmin", "-path", d, "dump", "-chain", "-json", "testApp"})
+			fmt.Println(out)
+			So(err, ShouldBeNil)
+			So(out, ShouldContainSubstring, "{\n    \"%dna\": {")
+		})
+	})
+}
+
 func runAppWithStdoutCapture(app *cli.App, args []string) (out string, err error) {
 	return cmd.RunAppWithStdoutCapture(app, args, time.Second*5)
 }


### PR DESCRIPTION
I've created an implementation for dumping the chain as json via the `--json` flag.  The format for the JSON was reviewed by @philipbeadle but it can be altered if it doesn't make sense.  I'm fairly new to Golang so I welcome any suggestions to improve the implementation or tests.  This PR does not include dumping the DHT as JSON.

This feature can serve as a basis for building a visualisation tool for the chain to help developers understand how the chain is structured and how it updates as they debug and test their Holochaibn apps.