### PR TITLE
Using multistage build and smaller base image for holochain docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,22 @@
-FROM golang
+#
+# Dockerfile using a multi-stage build
+#
+
+# Stage 0 (build) - Build the holochain tools
+
+FROM golang as build
 
 run go get -d -v github.com/metacurrency/holochain
 run cd $GOPATH/src/github.com/metacurrency/holochain && make
+
+# Stage 1 - Copy holochain tools into a minimal image
+
+FROM debian:buster-slim
+
+COPY --from=build /go/bin/bs /usr/local/bin/bs
+COPY --from=build /go/bin/hcadmin /usr/local/bin/hcadmin
+COPY --from=build /go/bin/hccore /usr/local/bin/hccore
+COPY --from=build /go/bin/hcd /usr/local/bin/hcd
+COPY --from=build /go/bin/hcdev /usr/local/bin/hcdev
+
+CMD ["/bin/bash"]


### PR DESCRIPTION
## Summary:

* Only required HC tools (binaries) are included in final image.
* Golang dev tools and libraries are omitted.

## Details:

The existing `Dockerfile` builds upon the `golang` base image -- which is rather large.  The resulting `metacurrency/holochain` Docker image is huge (1.3GB) as it includes Go lang tools, libraries, and other files unneeded after the core HC tools are built.

The approach used to reduce overall image size is to use a Multistage build (see: https://docs.docker.com/develop/develop-images/multistage-build/).  This lets you build your apps via one base image (e.g. `golang`) and then package the final artefacts into a smaller base image.  I have used `debian:buster-slim` as the base image and the resulting `metacurrency/holochain` Docker image is reduced to 229MB.

**Note**: It might be possible to use a smaller base image like Alpine Linux but there are hard dependencies on `bash` in the source code (bash can be installed via `apk add bash` in Alpine).  Debian is a more familiar Linux compared to Alpine, so the small reduction in size may not be worth it.

## Testing base image

I have tested the new Docker image with the Clutter app and it works (via the `docker-compose.yml` file).

```sh
cd clutter
docker-compose up
```

Check the app in your browser (`http://localhost:3141`) and it works.

## Size Comparisons

### Before

Base image:

```
golang    alpine     a8f345e387a3        5 days ago          269MB
```

Final image:

```
metacurrency/holochain       latest        8d55fc88e6d6        4 weeks ago         1.36GB
```

### After

Base image:

```
debian     buster-slim     94c04e4f5cd2        2 months ago        61.8MB
```

Final image:

```
metacurrency/holochain      latest    d152dad60446        38 minutes ago      229MB
```